### PR TITLE
Adding workdir parameter to the DockerExecutor message

### DIFF
--- a/proto/task_execution.proto
+++ b/proto/task_execution.proto
@@ -23,6 +23,11 @@ message TaskParameter {
   //data is a directory, if used for an output all the files in the directory
   //will be copied to the storage location
   bool   directory = 5;
+  //if the parameter is an output, should the element be created before executing
+  //the command. For example if saving the working directory as an output,
+  //the directory needs to exist before the command is called. If false, it is
+  //assumed that the user will create the element as a part of the operation
+  bool   create = 6;
 }
 
 //A command line to be executed and the docker container to run it

--- a/swagger/proto/task_execution.swagger.json
+++ b/swagger/proto/task_execution.swagger.json
@@ -395,6 +395,11 @@
     "ga4gh_task_execTaskParameter": {
       "type": "object",
       "properties": {
+        "create": {
+          "type": "boolean",
+          "format": "boolean",
+          "title": "if the parameter is an output, should the element be created before executing\nthe command. For example if saving the working directory as an output,\nthe directory needs to exist before the command is called. If false, it is\nassumed that the user will create the element as a part of the operation"
+        },
         "description": {
           "type": "string",
           "format": "string",


### PR DESCRIPTION
Adding a workdir file so that users can fill out the '--workdir' flag in the docker command and define which directory the command will be executed in.