### PR TITLE
Changing job log info command line format

### DIFF
--- a/proto/task_execution.proto
+++ b/proto/task_execution.proto
@@ -146,7 +146,7 @@ enum State {
 
 message JobLog {
   //The command line that was run
-  string commandLine = 1;
+  repeated string cmd = 1;
   //When the command was executed
   string startTime = 2;
   //When the command completed

--- a/swagger/proto/task_execution.swagger.json
+++ b/swagger/proto/task_execution.swagger.json
@@ -242,9 +242,12 @@
     "ga4gh_task_execJobLog": {
       "type": "object",
       "properties": {
-        "commandLine": {
-          "type": "string",
-          "format": "string",
+        "cmd": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "string"
+          },
           "title": "The command line that was run"
         },
         "endTime": {


### PR DESCRIPTION
Changing the command line description to be a repeated string in the log to match the task request.