### PR TITLE
Change jobListResponse to show JobID, not Job

### DIFF
--- a/proto/task_execution.proto
+++ b/proto/task_execution.proto
@@ -121,10 +121,14 @@ message JobListRequest {
   string pageToken = 4;
 }
 
+message JobDesc {
+  string jobID  = 1;
+  State state = 2;
+}
+
 message JobListResponse {
-  repeated string jobID  = 1;
-  repeated State state = 2;
-  string nextPageToken = 3;
+   repeated JobDesc jobs = 1;
+   string nextPageToken = 2;
 }
 
 //ID of a Task description

--- a/proto/task_execution.proto
+++ b/proto/task_execution.proto
@@ -123,7 +123,8 @@ message JobListRequest {
 
 message JobListResponse {
   repeated string jobID  = 1;
-  string nextPageToken = 2;
+  repeated State state = 2;
+  string nextPageToken = 3;
 }
 
 //ID of a Task description

--- a/proto/task_execution.proto
+++ b/proto/task_execution.proto
@@ -122,7 +122,7 @@ message JobListRequest {
 }
 
 message JobListResponse {
-  repeated Job jobs  = 1;
+  repeated string jobID  = 1;
   string nextPageToken = 2;
 }
 


### PR DESCRIPTION
This patch changes `jobListResponse` to include `JobID`s, instead of `Jobs`. This will make the returned value to be much smaller.