### PR TITLE
Remove references to Docker.

### DIFF
--- a/proto/task_execution.proto
+++ b/proto/task_execution.proto
@@ -52,8 +52,8 @@ message Ports {
   int32 host = 2;
 }
 
-//A command to be executed
-message Command {
+// Executor executes a task
+message Executor {
   //REQUIRED
   // Image name
   string imageName = 1;
@@ -136,8 +136,8 @@ message Task {
   //Define required system resources to run job
   Resources resources = 6;
   //REQUIRED
-  //A list of commands that will be run sequentially
-  repeated Command commands = 8;
+  //A list of executors that will be run sequentially
+  repeated Executor executors = 8;
 }
 
 //Request listing of jobs tracked by server

--- a/proto/task_execution.proto
+++ b/proto/task_execution.proto
@@ -52,15 +52,15 @@ message Ports {
   int32 host = 2;
 }
 
-//A command line to be executed and the docker container to run it
-message DockerExecutor {
+//A command to be executed
+message Command {
   //REQUIRED
-  //Docker Image name
+  // Image name
   string imageName = 1;
   //REQUIRED
   //The command to be executed
   repeated string cmd = 2;
-  //OPTIONAL: default docker image directory
+  //OPTIONAL: default image directory
   //The working directory that the command will be executed in
   string workdir = 3;
   //OPTIONAL
@@ -91,7 +91,7 @@ message Volume {
   //Volumes loaded from a source will be mounted as read only
   string source = 3;
   //REQUIRED
-  //mount point for volume inside the docker container
+  //mount point for volume
   string mountPoint = 6;
   //OPTIONAL default False
   bool readonly = 7;
@@ -108,7 +108,7 @@ message Resources {
   //Minimum RAM required
   double minimumRamGb = 3;
   //REQUIRED
-  //Volumes to be mounted into the docker container
+  //Volumes to be mounted
   repeated Volume volumes = 4;
   //OPTIONAL
   //optional scheduling information for systems where multiple compute zones are avalible
@@ -136,8 +136,8 @@ message Task {
   //Define required system resources to run job
   Resources resources = 6;
   //REQUIRED
-  //An array of docker executions that will be run sequentially
-  repeated DockerExecutor docker = 8;
+  //A list of commands that will be run sequentially
+  repeated Command commands = 8;
 }
 
 //Request listing of jobs tracked by server


### PR DESCRIPTION
Docker is not the only container runtime. We should not preemptively hard-code our schema to docker. Other runtimes include rkt, runC, lxc, systemd-nspawn, openvz, and more.

The [OCI](https://www.opencontainers.org/) is standardizing the container image format and runtime spec, which Docker is compatible with. Tasks should require only that the containers/images be in this format, and task execution servers should guarantee that containers will be run with an OCI compatible runtime, but there is no need require docker specifically. Docker is an implementation detail.