### PR TITLE
Output File listing

### DIFF
--- a/proto/task_execution.proto
+++ b/proto/task_execution.proto
@@ -221,6 +221,24 @@ message JobLog {
   repeated Ports ports = 8;
 }
 
+
+//Log of file output by workflow
+message FileLog {
+  //REQUIRED
+  //location in long term storage that the output file was copied to
+  //is a url specific to the implementing
+  //system. For example s3://my-object-store/file1 or gs://my-bucket/file2 or
+  //file:///path/to/my/file
+  string location = 1;
+  //REQUIRED
+  //path in the machine file system that originated the file
+  string path = 2;
+  //REQUIRED
+  //Size of produced file
+  int64  size = 3;
+}
+
+
 //The description of the running instance of a task
 message Job {
   string jobID = 1;
@@ -228,6 +246,10 @@ message Job {
   Task task = 3;
   State state = 4;
   repeated JobLog logs = 5;
+  //List of all files copied out to the object store as well as some basic
+  //meta-data about them. This is an expanded list, if the task outputs 
+  //list directories, this record details every individual file
+  repeated FileLog outputs = 6;
 }
 
 //Blank request message for service request

--- a/swagger/proto/task_execution.swagger.json
+++ b/swagger/proto/task_execution.swagger.json
@@ -212,6 +212,10 @@
         "state": {
           "$ref": "#/definitions/ga4gh_task_execState",
           "title": "REQUIRED"
+        },
+        "task": {
+          "$ref": "#/definitions/ga4gh_task_execTaskDesc",
+          "title": "REQUIRED short description of task"
         }
       },
       "title": "Small description of jobs, returned by server during listing"
@@ -446,6 +450,27 @@
         }
       },
       "title": "The description of a task to be run"
+    },
+    "ga4gh_task_execTaskDesc": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "format": "string",
+          "title": "OPTIONAL\nuser name for task"
+        },
+        "projectID": {
+          "type": "string",
+          "format": "string",
+          "title": "OPTIONAL\nparameter for execution engine to define/store group information"
+        },
+        "description": {
+          "type": "string",
+          "format": "string",
+          "title": "OPTIONAL\nfree text description of task"
+        }
+      },
+      "title": "Small description of tasks, returned by server during listing"
     },
     "ga4gh_task_execTaskParameter": {
       "type": "object",

--- a/swagger/proto/task_execution.swagger.json
+++ b/swagger/proto/task_execution.swagger.json
@@ -172,6 +172,27 @@
       },
       "title": "A command line to be executed and the docker container to run it"
     },
+    "ga4gh_task_execFileLog": {
+      "type": "object",
+      "properties": {
+        "location": {
+          "type": "string",
+          "format": "string",
+          "title": "REQUIRED\nlocation in long term storage that the output file was copied to\nis a url specific to the implementing\nsystem. For example s3://my-object-store/file1 or gs://my-bucket/file2 or\nfile:///path/to/my/file"
+        },
+        "path": {
+          "type": "string",
+          "format": "string",
+          "title": "REQUIRED\npath in the machine file system that originated the file"
+        },
+        "size": {
+          "type": "string",
+          "format": "int64",
+          "title": "REQUIRED\nSize of produced file"
+        }
+      },
+      "title": "Log of file output by workflow"
+    },
     "ga4gh_task_execJob": {
       "type": "object",
       "properties": {
@@ -197,6 +218,13 @@
           "items": {
             "$ref": "#/definitions/ga4gh_task_execJobLog"
           }
+        },
+        "outputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ga4gh_task_execFileLog"
+          },
+          "title": "List of all files copied out to the object store as well as some basic\nmeta-data about them. This is an expanded list, if the task outputs \nlist directories, this record details every individual file"
         }
       },
       "title": "The description of the running instance of a task"
@@ -328,12 +356,12 @@
         "container": {
           "type": "integer",
           "format": "int32",
-          "title": "REQUIRED \nExposed port on container"
+          "title": "REQUIRED\nExposed port on container"
         },
         "host": {
           "type": "integer",
           "format": "int32",
-          "title": "OPTIONAL \nMust be greater than 1024;\nDefaults to 0"
+          "title": "OPTIONAL\nMust be greater than 1024;\nDefaults to 0"
         }
       },
       "title": "host to container port mappings"


### PR DESCRIPTION
This adds a record of all output files (and file size) to job record. This expands on the `outputs` TaskParameter as that is a request, that can include base directories, and this is the manifest of what was actually done including all files contained in those directories.

Many workflow engines need to 'glob' the output directories to see what files were created (as some of the file names are not predetermined). Without this listing, it is incumbent on the workflow engine to independently contact the object store and get the listing manually. Having this listing removes the need for that. 