### PR TITLE
Output File listing

### DIFF
--- a/proto/task_execution.proto
+++ b/proto/task_execution.proto
@@ -187,6 +187,24 @@ message JobLog {
   int32  exitCode = 6;
 }
 
+
+//Log of file output by workflow
+message FileLog {
+  //REQUIRED
+  //location in long term storage that the output file was copied to
+  //is a url specific to the implementing
+  //system. For example s3://my-object-store/file1 or gs://my-bucket/file2 or
+  //file:///path/to/my/file
+  string location = 1;
+  //REQUIRED
+  //path in the machine file system that originated the file
+  string path = 2;
+  //REQUIRED
+  //Size of produced file
+  int64  size = 3;
+}
+
+
 //The description of the running instance of a task
 message Job {
   string jobID = 1;
@@ -194,6 +212,10 @@ message Job {
   Task task = 3;
   State state = 4;
   repeated JobLog logs = 5;
+  //List of all files copied out to the object store as well as some basic
+  //meta-data about them. This is an expanded list, if the task outputs 
+  //list directories, this record details every individual file
+  repeated FileLog outputs = 6;
 }
 
 //Blank request message for service request

--- a/swagger/proto/task_execution.swagger.json
+++ b/swagger/proto/task_execution.swagger.json
@@ -165,6 +165,27 @@
       },
       "title": "A command line to be executed and the docker container to run it"
     },
+    "ga4gh_task_execFileLog": {
+      "type": "object",
+      "properties": {
+        "location": {
+          "type": "string",
+          "format": "string",
+          "title": "REQUIRED\nlocation in long term storage that the output file was copied to\nis a url specific to the implementing\nsystem. For example s3://my-object-store/file1 or gs://my-bucket/file2 or\nfile:///path/to/my/file"
+        },
+        "path": {
+          "type": "string",
+          "format": "string",
+          "title": "REQUIRED\npath in the machine file system that originated the file"
+        },
+        "size": {
+          "type": "string",
+          "format": "int64",
+          "title": "REQUIRED\nSize of produced file"
+        }
+      },
+      "title": "Log of file output by workflow"
+    },
     "ga4gh_task_execJob": {
       "type": "object",
       "properties": {
@@ -190,6 +211,13 @@
           "items": {
             "$ref": "#/definitions/ga4gh_task_execJobLog"
           }
+        },
+        "outputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ga4gh_task_execFileLog"
+          },
+          "title": "List of all files copied out to the object store as well as some basic\nmeta-data about them. This is an expanded list, if the task outputs \nlist directories, this record details every individual file"
         }
       },
       "title": "The description of the running instance of a task"


### PR DESCRIPTION
(resubmit of https://github.com/ga4gh/task-execution-schemas/pull/25 without other changes)

This adds a record of all output files (and file size) to job record. This expands on the outputs TaskParameter as that is a request, that can include base directories, and this is the manifest of what was actually done including all files contained in those directories.

Many workflow engines need to 'glob' the output directories to see what files were created (as some of the file names are not predetermined). Without this listing, it is incumbent on the workflow engine to independently contact the object store and get the listing manually. Having this listing removes the need for that.