### PR TITLE
Redefining Volumes

### DIFF
--- a/proto/task_execution.proto
+++ b/proto/task_execution.proto
@@ -85,16 +85,9 @@ message Volume {
   //REQUIRED
   //Minimum size
   double sizeGb = 2;
-  //OPTIONAL
-  //Source volume, this would refer to an existing volume the execution engine
-  //could identify. Leave blank if is to be a newly created volume
-  //Volumes loaded from a source will be mounted as read only
-  string source = 3;
   //REQUIRED
   //mount point for volume inside the docker container
   string mountPoint = 6;
-  //OPTIONAL default False
-  bool readonly = 7;
 }
 
 message Resources {

--- a/swagger/proto/task_execution.swagger.json
+++ b/swagger/proto/task_execution.swagger.json
@@ -521,18 +521,9 @@
           "format": "double",
           "title": "REQUIRED\nMinimum size"
         },
-        "source": {
-          "type": "string",
-          "title": "OPTIONAL\nSource volume, this would refer to an existing volume the execution engine\ncould identify. Leave blank if is to be a newly created volume\nVolumes loaded from a source will be mounted as read only"
-        },
         "mountPoint": {
           "type": "string",
           "title": "REQUIRED\nmount point for volume inside the docker container"
-        },
-        "readonly": {
-          "type": "boolean",
-          "format": "boolean",
-          "title": "OPTIONAL default False"
         }
       },
       "description": "Attached volume request."


### PR DESCRIPTION
Addresses #18 :
* Input files are read-only and not in a volume
* Volumes are used for output and temp space
* May have multiple volumes and specify outputs on multiple volumes

From Mar 27th call:
* source field adds unnecessary complexity so we are removing it
