### PR TITLE
remove redundant field

### DIFF
--- a/proto/task_execution.proto
+++ b/proto/task_execution.proto
@@ -188,8 +188,6 @@ enum State {
 }
 
 message JobLog {
-  //The command line that was run
-  repeated string cmd = 1;
   //When the command was executed
   string startTime = 2;
   //When the command completed

--- a/swagger/proto/task_execution.swagger.json
+++ b/swagger/proto/task_execution.swagger.json
@@ -312,13 +312,6 @@
     "ga4gh_task_execJobLog": {
       "type": "object",
       "properties": {
-        "cmd": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "title": "The command line that was run"
-        },
         "startTime": {
           "type": "string",
           "title": "When the command was executed"


### PR DESCRIPTION
Removes the redundant `cmd` field in `JobLog`