### PR TITLE
Remove (or clarify) TaskParameter.create

### DIFF
--- a/proto/task_execution.proto
+++ b/proto/task_execution.proto
@@ -33,12 +33,6 @@ message TaskParameter {
   //if used for an output all the files in the directory
   //will be copied to the storage location
   string class = 5;
-  //OPTIONAL: default false
-  //if the parameter is an output, should the element be created before executing
-  //the command. For example if saving the working directory as an output,
-  //the directory needs to exist before the command is called. If false, it is
-  //assumed that the user will create the element as a part of the operation
-  bool   create = 6;
 }
 
 //host to container port mappings


### PR DESCRIPTION
Possibly, the `TaskParameter.create` field is not needed. If an output directory needs to exist, that can easily (and more consistently) be done with volumes. I don't think there's a case where an output file needs to be created, so this is directory specific.

If there's a good use case for this field, then I'd at least like to get that case clearly documented.