### PR TITLE
Rename Job -> Task. Also, proof read and clean up.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,10 @@ export GOPATH
 PATH := ${PATH}:$(shell pwd)/bin
 export PATH
 
-PROTO_INC= -I ./ -I $(GOPATH)/src/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis/ -I proto/
+PROTO_INC= -I ./ \
+	-I $(GOPATH)/src/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis/ \
+	-I googleapis/ \
+	-I proto/
 
 all: swagger
 

--- a/proto/task_execution.proto
+++ b/proto/task_execution.proto
@@ -198,7 +198,9 @@ message Resources {
 // GetTaskRequest describes a request to the GetTask endpoint.
 message GetTaskRequest {
   // REQUIRED
-  string task_id = 1;
+  //
+  // Task identifier.
+  string id = 1;
 }
 
 // OUTPUT ONLY
@@ -207,7 +209,9 @@ message GetTaskRequest {
 message Task {
 
   // REQUIRED
-  string task_id = 1;
+  //
+  // Task identifier.
+  string id = 1;
 
   // REQUIRED
   map<string,string> metadata = 2;
@@ -363,7 +367,9 @@ message ListTasksResponse {
 message TaskDesc {
 
   // REQUIRED
-  string task_id = 1;
+  //
+  // Task identifier.
+  string id = 1;
 
   // REQUIRED
   State state = 2;
@@ -372,7 +378,9 @@ message TaskDesc {
 // CancelTaskRequest describes a request to the CancelTask endpoint.
 message CancelTaskRequest {
   // REQUIRED
-  string task_id = 1;
+  //
+  // Task identifier.
+  string id = 1;
 }
 
 // OUTPUT ONLY
@@ -429,14 +437,14 @@ service TaskService {
   // Get a task.
   rpc GetTask(GetTaskRequest) returns (Task) {
       option (google.api.http) = {
-        get: "/v1/tasks/{task_id}"
+        get: "/v1/tasks/{id}"
       };
   }
 
   // Cancel a task.
   rpc CancelTask(CancelTaskRequest) returns (CancelTaskResponse) {
     option (google.api.http) = {
-      post: "/v1/tasks/{task_id}:cancel"
+      post: "/v1/tasks/{id}:cancel"
       body: "*"
     };
   }

--- a/proto/task_execution.proto
+++ b/proto/task_execution.proto
@@ -44,6 +44,11 @@ message CreateTaskRequest {
   repeated Executor executors = 8;
 }
 
+enum FileType {
+  FILE = 0
+  DIRECTORY = 1
+}
+
 // TaskParameter describes input and output files for a Task.
 message TaskParameter {
 
@@ -70,8 +75,8 @@ message TaskParameter {
 
   // REQUIRED
   //
-  // Type of the file: "File" or "Directory".
-  string class = 5;
+  // Type of the file, FILE or DIRECTORY
+  FileType type = 5;
 
   // OPTIONAL
   //

--- a/proto/task_execution.proto
+++ b/proto/task_execution.proto
@@ -297,7 +297,7 @@ message OutputFileLog {
   // REQUIRED
   //
   // Size of the file in bytes.
-  int64 size = 3;
+  int64 size_bytes = 3;
 }
 
 // OUTPUT ONLY

--- a/proto/task_execution.proto
+++ b/proto/task_execution.proto
@@ -1,299 +1,443 @@
-
-
 syntax = "proto3";
 
-package ga4gh_task_exec;
+package tes;
 
-// Import HTTP RESTful annotations
+// Import HTTP RESTful annotations.
 import "google/api/annotations.proto";
 
-//Parameters for Task
-message TaskParameter {
-  //OPTIONAL
-  //name of the parameter
+// CreateTaskRequest describes a task to be created and run.
+message CreateTaskRequest {
+
+  // OPTIONAL
   string name = 1;
-  //OPTIONAL
-  //Text description
-  string description = 2;
-  //REQUIRED
-  //url in long term storage, is a url specific to the implementing
-  //system. For example s3://my-object-store/file1 or gs://my-bucket/file2 or
-  //file:///path/to/my/file
-  string url = 3;
-  //REQUIRED
-  //path in the machine file system. Note, this MUST be a path that exists
-  //within one of the defined volumes
-  //If the file is mounted in a volume that is mounted read/write the file must
-  //be accessable to processes in the container. Optimizations, suc as hard linking
-  //to a source file, or providing a streaming input from a FUSE mount should only
-  //be done if the volume is mounted as read only
-  string path = 4;
-  //REQUIRED
-  //Type of data, "File" or "Directory"
-  //if used for an output all the files in the directory
-  //will be copied to the storage url
-  string class = 5;
-  //OPTIONAL: default false
-  //if the parameter is an output, should the element be created before executing
-  //the command. For example if saving the working directory as an output,
-  //the directory needs to exist before the command is called. If false, it is
-  //assumed that the user will create the element as a part of the operation
-  bool   create = 6;
-}
 
-//host to container port mappings
-message Ports {
-  //REQUIRED 
-  //Exposed port on container
-  uint32 container = 1;
-  //OPTIONAL 
-  //Must be greater than 1024;
-  //Defaults to 0
-  uint32 host = 2;
-}
+  // OPTIONAL
+  //
+  // Describes the project this task is associated with.
+  // Commonly used for billing on cloud providers (AWS, Google Cloud, etc).
+  string project = 2;
 
-// Executor executes a task
-message Executor {
-  //REQUIRED
-  // Image name
-  string imageName = 1;
-  //REQUIRED
-  //The command to be executed
-  repeated string cmd = 2;
-  //OPTIONAL: default image directory
-  //The working directory that the command will be executed in
-  string workdir = 3;
-  //OPTIONAL
-  //Path for supplying input to stdin, blank if none
-  string stdin = 6;
-  //OPTIONAL
-  //Path for stdout recording, blank if not storing to file
-  string stdout = 4;
-  //OPTIONAL
-  //Path for stderr recording, blank if not storing to file
-  string stderr = 5;
-  //OPTIONAL
-  //Port to expose from within the container, blank if none
-  repeated Ports ports = 7;
-  //OPTIONAL
-  //Enviromental variables to set within the container
-  map<string,string> environ = 8;
-}
-
-//Attached volume request.
-message Volume {
-  //OPTIONAL
-  //Name of attached volume
-  string name = 1;
-  //REQUIRED
-  //Minimum size
-  double sizeGb = 2;
-  //REQUIRED
-  //mount point for volume
-  string mountPoint = 6;
-}
-
-message Resources {
-  //OPTIONAL default 1
-  //Minimum number of CPUs
-  uint32 minimumCpuCores = 1;
-  //Can schedule on resource that resource that can be preempted, like AWS Spot Instances
-  //OPTIONAL default false
-  bool preemptible = 2;
-  //REQUIRED
-  //Minimum RAM required
-  double minimumRamGb = 3;
-  //REQUIRED
-  //Volumes to be mounted
-  repeated Volume volumes = 4;
-  //OPTIONAL
-  //optional scheduling information for systems where multiple compute zones are avalible
-  repeated string zones = 5;
-}
-
-//The description of a task to be run
-message Task {
-  //OPTIONAL
-  //user name for task
-  string name = 1;
-  //OPTIONAL
-  //parameter for execution engine to define/store group information
-  string projectID = 2;
-  //OPTIONAL
-  //free text description of task
+  // OPTIONAL
   string description = 3;
-  //REQUIRED
-  //Files to be copied into system before tasks
+
+  // OPTIONAL
+  //
+  // Input files.
+  // Inputs will be downloaded and mounted into the executor container.
   repeated TaskParameter inputs = 4;
-  //REQUIRED
-  //Files to be copied out of the system after tasks
+
+  // OPTIONAL
+  //
+  // Output files.
+  // Outputs will be uploaded from the executor container to long-term storage.
   repeated TaskParameter outputs = 5;
-  //REQUIRED
-  //Define required system resources to run job
+
+  // OPTIONAL
+  //
+  // Request that the task be run with these resources.
   Resources resources = 6;
-  //REQUIRED
-  //A list of executors that will be run sequentially
+
+  // REQUIRED
+  //
+  // A list of executors to be run, sequentially.
   repeated Executor executors = 8;
 }
 
-//Request listing of jobs tracked by server
-message JobListRequest {
-  //OPTIONAL
-  //The name of the project to search for pipelines. Caller must have READ access to this project.
-  string projectID = 1;
-  //OPTIONAL
-  //Pipelines with names that match this prefix should be returned. If unspecified, all pipelines in the project, up to pageSize, will be returned.
-  string namePrefix	= 2;
-  //OPTIONAL
-  //Number of pipelines to return at once. Defaults to 256, and max is 2048.
-  uint32 pageSize = 3;
-  //OPTIONAL
-  //Token to use to indicate where to start getting results. If unspecified, returns the first page of results.
-  string pageToken = 4;
+// TaskParameter describes input and output files for a Task.
+message TaskParameter {
+
+  // OPTIONAL
+  string name = 1;
+
+  // OPTIONAL
+  string description = 2;
+
+  // REQUIRED
+  //
+  // URL in long term storage, for example:
+  // s3://my-object-store/file1
+  // gs://my-bucket/file2
+  // file:///path/to/my/file
+  // /path/to/my/file
+  // etc...
+  string url = 3;
+
+  // REQUIRED
+  //
+  // Path of the file inside the container.
+  string path = 4;
+
+  // REQUIRED
+  //
+  // Type of the file: "File" or "Directory".
+  string class = 5;
+
+  // OPTIONAL
+  //
+  // If true, this path will be created before the task starts running.
+  // This helps tasks create output directories which the task will
+  // write to.
+  bool create = 6;
 }
 
-//Small description of jobs, returned by server during listing
-message JobDesc {
-  //REQUIRED
-  string jobID  = 1;
-  //REQUIRED
-  State state = 2;
+// Ports describes the port mapping between the container and host.
+message Ports {
+
+  // REQUIRED 
+  //
+  // Port number opened inside the container.
+  uint32 container = 1;
+
+  // OPTIONAL 
+  //
+  // Port number opened on the host. Must be greater than 1024.
+  // Defaults to 0, which assigns a random port on the host.
+  uint32 host = 2;
 }
 
-//Return envelope
-message JobListResponse {
-   repeated JobDesc jobs = 1;
-   string nextPageToken = 2;
-}
+// Executor describes a command to run, and its environment.
+message Executor {
 
-enum State {
-  Unknown = 0;
-  Queued = 1;
-  Running = 2;
-  Paused = 3;
-  Complete = 4;
-  Error = 5;
-  SystemError = 6;
-  Canceled = 7;
-  Initializing = 8;
-}
+  // REQUIRED
+  //
+  // Name of the container image, for example:
+  // ubuntu
+  // quay.io/aptible/ubuntu
+  // gcr.io/my-org/my-image
+  // etc...
+  string image_name = 1;
 
-message JobLog {
-  //When the command was executed in ISO 8601 format
-  string startTime = 2;
-  //When the command completed in ISO 8601 format
-  string endTime = 3;
-  //Sample of stdout (not guaranteed to be entire log)
+  // REQUIRED
+  //
+  // The command to be executed.
+  repeated string cmd = 2;
+
+  // OPTIONAL
+  //
+  // The working directory that the command will be executed in.
+  // Defaults to the directory set by the container image.
+  string workdir = 3;
+
+  // OPTIONAL
+  //
+  // Path inside the container to a file which will be piped
+  // to the command's stdin.
+  string stdin = 6;
+
+  // OPTIONAL
+  //
+  // Path inside the container to a file where the command's
+  // stdout will be written to.
   string stdout = 4;
-  //Sample of stderr (not guaranteed to be entire log)
+
+  // OPTIONAL
+  //
+  // Path inside the container to a file where the command's
+  // stderr will be written to.
   string stderr = 5;
-  //Exit code of the program
-  int32  exitCode = 6;
-  // ip of worker host
-  string hostIP = 7;
-  // ports bound from container to host
+
+  // OPTIONAL
+  //
+  // Port to expose from within the container, blank if none.
+  repeated Ports ports = 7;
+
+  // OPTIONAL
+  //
+  // Enviromental variables to set within the container.
+  map<string,string> environ = 8;
+}
+
+// Volume describes a volume (i.e. directory) which will be
+// mounted into an executor/container.
+message Volume {
+
+  // OPTIONAL
+  string name = 1;
+
+  // REQUIRED
+  //
+  // Requested disk size in gigabytes (GB)
+  double size_gb = 2;
+
+  // REQUIRED
+  //
+  // Path inside the container that the volume will be mounted to.
+  string mount_point = 6;
+}
+
+// Resources describes the resources requested by a task.
+message Resources {
+
+  // OPTIONAL
+  //
+  // Minimum number of CPUs
+  // Default 1
+  uint32 minimum_cpu_cores = 1;
+
+  // OPTIONAL
+  //
+  // Is the task allowed to run on preemptible compute instances (e.g. AWS Spot)?
+  bool preemptible = 2;
+
+  // OPTIONAL
+  //
+  // Minimum RAM required in gigabytes (GB)
+  double minimum_ram_gb = 3;
+
+  // OPTIONAL
+  //
+  // Volumes to be mounted into the container.
+  repeated Volume volumes = 4;
+
+  // OPTIONAL
+  //
+  // Request that the task be run in these compute zones.
+  repeated string zones = 5;
+}
+
+// GetTaskRequest describes a request to the GetTask endpoint.
+message GetTaskRequest {
+  // REQUIRED
+  string task_id = 1;
+}
+
+// OUTPUT ONLY
+//
+// Task describes an instance of a task.
+message Task {
+
+  // REQUIRED
+  string task_id = 1;
+
+  // REQUIRED
+  map<string,string> metadata = 2;
+
+  // REQUIRED
+  Task task = 3;
+
+  // REQUIRED
+  State state = 4;
+
+  // REQUIRED
+  repeated ExecutorLog logs = 5;
+
+  // REQUIRED
+  //
+  // Information about all output files. Directory outputs are
+  // flattened into separate items.
+  repeated OutputFileLog outputs = 6;
+}
+
+// OUTPUT ONLY
+//
+// ExecutorLog describes logging information related to an Executor.
+message ExecutorLog {
+
+  // OPTIONAL
+  //
+  // Time the executor was started, in ISO 8601 format.
+  string start_time = 2;
+
+  // OPTIONAL
+  //
+  // Time the executor ended, in ISO 8601 format.
+  string end_time = 3;
+
+  // OPTIONAL
+  //
+  // Stdout tail.
+  // This is not guaranteed to be the entire log.
+  // Implementations determine the maximum size.
+  string stdout = 4;
+
+  // OPTIONAL
+  //
+  // Stderr tail.
+  // This is not guaranteed to be the entire log.
+  // Implementations determine the maximum size.
+  string stderr = 5;
+
+  // REQUIRED
+  //
+  // Exit code.
+  int32 exit_code = 6;
+
+  // OPTIONAL
+  //
+  // IP address of host.
+  string host_ip = 7;
+
+  // OPTIONAL
+  //
+  // Ports mapped between the container and host.
   repeated Ports ports = 8;
 }
 
+// OUTPUT ONLY
+//
+// OutputFileLog describes a single output file. This describes
+// file details after the task has completed successfully,
+// for logging purposes.
+message OutputFileLog {
 
-//Log of file output by workflow
-message FileLog {
-  //REQUIRED
-  //url of long term storage that the output file was copied to
-  //is a url specific to the implementing
-  //system. For example s3://my-object-store/file1 or gs://my-bucket/file2 or
-  //file:///path/to/my/file
+  // REQUIRED
+  //
+  // URL of the file in storage, e.g. s3://bucket/file.txt
   string url = 1;
-  //REQUIRED
-  //path in the machine file system that originated the file
+
+  // REQUIRED
+  //
+  // Path of the file inside the container.
   string path = 2;
-  //REQUIRED
-  //Size of produced file
-  int64  size = 3;
+
+  // REQUIRED
+  //
+  // Size of the file in bytes.
+  int64 size = 3;
 }
 
-
-//The description of the running instance of a task
-message Job {
-  string jobID = 1;
-  map<string,string> metadata = 2;
-  Task task = 3;
-  State state = 4;
-  repeated JobLog logs = 5;
-  //List of all files copied out to the object store as well as some basic
-  //meta-data about them. This is an expanded list, if the task outputs 
-  //list directories, this record details every individual file
-  repeated FileLog outputs = 6;
+// OUTPUT ONLY
+//
+// Task states.
+enum State {
+  UNKNOWN = 0;
+  QUEUED = 1;
+  INITIALIZING = 2;
+  RUNNING = 3;
+  PAUSED = 4;
+  COMPLETE = 5;
+  ERROR = 6;
+  SYSTEM_ERROR = 7;
+  CANCELED = 8;
 }
 
-//Blank request message for service request
+// ListTasksRequest describes a request to the ListTasks service endpoint.
+message ListTasksRequest {
+
+  // OPTIONAL
+  //
+  // Filter the task list to include tasks in this project.
+  string project = 1;
+
+  // OPTIONAL
+  //
+  // Filter the list to include tasks where the name matches this prefix.
+  // If unspecified, no task name filtering is done.
+  string name_prefix	= 2;
+
+  // OPTIONAL
+  //
+  // Number of tasks to return in one page.
+  // Must be less than 2048. Defaults to 256.
+  uint32 page_size = 3;
+
+  // OPTIONAL
+  //
+  // Page token is used to retrieve the next page of results.
+  // If unspecified, returns the first page of results.
+  // See ListTasksResponse.next_page_token
+  string page_token = 4;
+}
+
+// OUTPUT ONLY
+//
+// ListTasksResponse describes a response from the ListTasks endpoint.
+message ListTasksResponse {
+
+  // REQUIRED
+  //
+  // List of lightweight task descriptions.
+  repeated TaskDesc tasks = 1;
+
+  // OPTIONAL
+  //
+  // Token used to return the next page of results.
+  // See TaskListRequest.next_page_token
+  string next_page_token = 2;
+}
+
+// OUTPUT ONLY
+//
+// TaskDesc is a lightweight description of a task, which is returned
+// by the ListTasks endpoint.
+message TaskDesc {
+
+  // REQUIRED
+  string task_id = 1;
+
+  // REQUIRED
+  State state = 2;
+}
+
+// CancelTaskRequest describes a request to the CancelTask endpoint.
+message CancelTaskRequest {
+  // REQUIRED
+  string task_id = 1;
+}
+
+// OUTPUT ONLY
+//
+// CancelTaskResponse describes a response from the CancelTask endpoint.
+message CancelTaskResponse {}
+
+// ServiceInfoRequest describes a request to the ServiceInfo endpoint.
 message ServiceInfoRequest {}
 
-//Information about Task Execution Service
-//May include information related (but not limited to)
-//resource availability and storage system information
-message ServiceInfoResponse {
-  //System specific key/value pairs
-  //Example for a shared file system based storage system:
-  //storageType=sharedFile, baseDir=/path/to/shared/directory
-  map<string,string> storageConfig = 1;
+// OUTPUT ONLY
+//
+// ServiceInfo describes information about the service,
+// such as storage details, resource availability,
+// and other documentation.
+message ServiceInfo {
+
+  // OPTIONAL
+  //
+  // System specific key/value pairs
+  // Example for a shared file system based storage system:
+  // storageType=sharedFile, baseDir=/path/to/shared/directory
+  map<string,string> storage_config = 1;
 }
 
-message GetJobRequest {
-  string jobID = 1;
-}
-
-message GetJobResponse {
-  Job job = 1;
-}
-
-//ID of an instance of a Task
-message RunTaskResponse {
-  string jobID = 1;
-}
-
-message CancelJobRequest {
-  string jobID = 1;
-}
-
-message CancelJobResponse {}
-
-//Web service to get, create, list and delete Tasks
+// TaskService describes the HTTP/gRPC service API provided by TES
+// services to create, list, get, update tasks.
 service TaskService {
 
-  //Get Service Info
-  rpc GetServiceInfo(ServiceInfoRequest) returns (ServiceInfoResponse) {
+  // GetServiceInfo provides information about the service,
+  // such as storage details, resource availability, and 
+  // other documentation.
+  rpc GetServiceInfo(ServiceInfoRequest) returns (ServiceInfo) {
     option (google.api.http) = {
-      get: "/v1/jobs-service"
+      get: "/v1/service-info"
     };
   }
 
-  //Run a task
-  rpc RunTask(Task) returns (RunTaskResponse) {
+  // Create a new task.
+  rpc CreateTask(CreateTaskRequest) returns (Task) {
     option (google.api.http) = {
-      post: "/v1/jobs"
+      post: "/v1/tasks"
       body: "*"
     };
   }
 
-  //List the TaskOps
-  rpc ListJobs(JobListRequest) returns (JobListResponse) {
+  // List tasks.
+  rpc ListTasks(ListTasksRequest) returns (ListTasksResponse) {
     option (google.api.http) = {
-      get: "/v1/jobs"
+      get: "/v1/tasks"
     };
   }
 
-  //Get info about a running task
-  rpc GetJob(GetJobRequest) returns (GetJobResponse) {
+  // Get a task.
+  rpc GetTask(GetTaskRequest) returns (Task) {
       option (google.api.http) = {
-        get: "/v1/jobs/{jobID}"
+        get: "/v1/tasks/{task_id}"
       };
   }
 
-  //Cancel a running task
-  rpc CancelJob(CancelJobRequest) returns (CancelJobResponse) {
+  // Cancel a task.
+  rpc CancelTask(CancelTaskRequest) returns (CancelTaskResponse) {
     option (google.api.http) = {
-      delete: "/v1/jobs/{jobID}"
+      post: "/v1/tasks/{task_id}:cancel"
+      body: "*"
     };
   }
 

--- a/proto/task_execution.proto
+++ b/proto/task_execution.proto
@@ -423,7 +423,7 @@ service TaskService {
   // other documentation.
   rpc GetServiceInfo(ServiceInfoRequest) returns (ServiceInfo) {
     option (google.api.http) = {
-      get: "/v1/service-info"
+      get: "/v1/tasks/service-info"
     };
   }
 

--- a/proto/task_execution.proto
+++ b/proto/task_execution.proto
@@ -245,13 +245,13 @@ message ExecutorLog {
 
   // OPTIONAL
   //
-  // Time the executor was started.
-  google.type.TimeOfDay start_time = 2;
+  // Time the executor started, in RFC 3339 format.
+  string start_time = 2;
 
   // OPTIONAL
   //
-  // Time the executor ended.
-  google.type.TimeOfDay end_time = 3;
+  // Time the executor ended, in RFC 3339 format.
+  string end_time = 3;
 
   // OPTIONAL
   //

--- a/proto/task_execution.proto
+++ b/proto/task_execution.proto
@@ -213,7 +213,7 @@ message Task {
   map<string,string> metadata = 2;
 
   // REQUIRED
-  Task task = 3;
+  CreateTaskRequest request = 3;
 
   // REQUIRED
   State state = 4;

--- a/proto/task_execution.proto
+++ b/proto/task_execution.proto
@@ -314,6 +314,8 @@ enum State {
   QUEUED = 1;
   INITIALIZING = 2;
   RUNNING = 3;
+  // An implementation *may* have the ability to pause a task,
+  // but this is not required.
   PAUSED = 4;
   COMPLETE = 5;
   ERROR = 6;

--- a/proto/task_execution.proto
+++ b/proto/task_execution.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package tes;
 
+import "google/type/timeofday.proto";
 // Import HTTP RESTful annotations.
 import "google/api/annotations.proto";
 
@@ -239,13 +240,13 @@ message ExecutorLog {
 
   // OPTIONAL
   //
-  // Time the executor was started, in ISO 8601 format.
-  string start_time = 2;
+  // Time the executor was started.
+  google.type.TimeOfDay start_time = 2;
 
   // OPTIONAL
   //
-  // Time the executor ended, in ISO 8601 format.
-  string end_time = 3;
+  // Time the executor ended.
+  google.type.TimeOfDay end_time = 3;
 
   // OPTIONAL
   //

--- a/swagger/proto/task_execution.swagger.json
+++ b/swagger/proto/task_execution.swagger.json
@@ -15,44 +15,61 @@
     "application/json"
   ],
   "paths": {
-    "/v1/jobs": {
+    "/v1/service-info": {
       "get": {
-        "summary": "List the TaskOps",
-        "operationId": "ListJobs",
+        "summary": "GetServiceInfo provides information about the service,\nsuch as storage details, resource availability, and \nother documentation.",
+        "operationId": "GetServiceInfo",
         "responses": {
           "200": {
             "description": "",
             "schema": {
-              "$ref": "#/definitions/ga4gh_task_execJobListResponse"
+              "$ref": "#/definitions/tesServiceInfo"
+            }
+          }
+        },
+        "tags": [
+          "TaskService"
+        ]
+      }
+    },
+    "/v1/tasks": {
+      "get": {
+        "summary": "List tasks.",
+        "operationId": "ListTasks",
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/tesListTasksResponse"
             }
           }
         },
         "parameters": [
           {
-            "name": "projectID",
-            "description": "OPTIONAL\nThe name of the project to search for pipelines. Caller must have READ access to this project.",
+            "name": "project",
+            "description": "OPTIONAL. Filter the task list to include tasks in this project.",
             "in": "query",
             "required": false,
             "type": "string"
           },
           {
-            "name": "namePrefix",
-            "description": "OPTIONAL\nPipelines with names that match this prefix should be returned. If unspecified, all pipelines in the project, up to pageSize, will be returned.",
+            "name": "name_prefix",
+            "description": "OPTIONAL. Filter the list to include tasks where the name matches this prefix.\nIf unspecified, no task name filtering is done.",
             "in": "query",
             "required": false,
             "type": "string"
           },
           {
-            "name": "pageSize",
-            "description": "OPTIONAL\nNumber of pipelines to return at once. Defaults to 256, and max is 2048.",
+            "name": "page_size",
+            "description": "OPTIONAL. Number of tasks to return in one page.\nMust be less than 2048. Defaults to 256.",
             "in": "query",
             "required": false,
             "type": "integer",
             "format": "int64"
           },
           {
-            "name": "pageToken",
-            "description": "OPTIONAL\nToken to use to indicate where to start getting results. If unspecified, returns the first page of results.",
+            "name": "page_token",
+            "description": "OPTIONAL. Page token is used to retrieve the next page of results.\nIf unspecified, returns the first page of results.\nSee ListTasksResponse.next_page_token",
             "in": "query",
             "required": false,
             "type": "string"
@@ -63,13 +80,13 @@
         ]
       },
       "post": {
-        "summary": "Run a task",
-        "operationId": "RunTask",
+        "summary": "Create a new task.",
+        "operationId": "CreateTask",
         "responses": {
           "200": {
             "description": "",
             "schema": {
-              "$ref": "#/definitions/ga4gh_task_execJobID"
+              "$ref": "#/definitions/tesTask"
             }
           }
         },
@@ -79,7 +96,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/ga4gh_task_execTask"
+              "$ref": "#/definitions/tesCreateTaskRequest"
             }
           }
         ],
@@ -88,38 +105,21 @@
         ]
       }
     },
-    "/v1/jobs-service": {
+    "/v1/tasks/{task_id}": {
       "get": {
-        "summary": "Get Service Info",
-        "operationId": "GetServiceInfo",
+        "summary": "Get a task.",
+        "operationId": "GetTask",
         "responses": {
           "200": {
             "description": "",
             "schema": {
-              "$ref": "#/definitions/ga4gh_task_execServiceInfo"
-            }
-          }
-        },
-        "tags": [
-          "TaskService"
-        ]
-      }
-    },
-    "/v1/jobs/{value}": {
-      "get": {
-        "summary": "Get info about a running task",
-        "operationId": "GetJob",
-        "responses": {
-          "200": {
-            "description": "",
-            "schema": {
-              "$ref": "#/definitions/ga4gh_task_execJob"
+              "$ref": "#/definitions/tesTask"
             }
           }
         },
         "parameters": [
           {
-            "name": "value",
+            "name": "task_id",
             "in": "path",
             "required": true,
             "type": "string"
@@ -128,24 +128,34 @@
         "tags": [
           "TaskService"
         ]
-      },
-      "delete": {
-        "summary": "Cancel a running task",
-        "operationId": "CancelJob",
+      }
+    },
+    "/v1/tasks/{task_id}:cancel": {
+      "post": {
+        "summary": "Cancel a task.",
+        "operationId": "CancelTask",
         "responses": {
           "200": {
             "description": "",
             "schema": {
-              "$ref": "#/definitions/ga4gh_task_execJobID"
+              "$ref": "#/definitions/tesCancelTaskResponse"
             }
           }
         },
         "parameters": [
           {
-            "name": "value",
+            "name": "task_id",
             "in": "path",
             "required": true,
             "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/tesCancelTaskRequest"
+            }
           }
         ],
         "tags": [
@@ -155,378 +165,455 @@
     }
   },
   "definitions": {
-    "ga4gh_task_execDockerExecutor": {
+    "tesCancelTaskRequest": {
       "type": "object",
       "properties": {
-        "imageName": {
+        "task_id": {
           "type": "string",
-          "title": "REQUIRED\nDocker Image name"
+          "title": "REQUIRED"
+        }
+      },
+      "description": "CancelTaskRequest describes a request to the CancelTask endpoint."
+    },
+    "tesCancelTaskResponse": {
+      "type": "object",
+      "description": "CancelTaskResponse describes a response from the CancelTask endpoint.",
+      "title": "OUTPUT ONLY"
+    },
+    "tesCreateTaskRequest": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "OPTIONAL"
+        },
+        "project": {
+          "type": "string",
+          "description": "Describes the project this task is associated with.\nCommonly used for billing on cloud providers (AWS, Google Cloud, etc).",
+          "title": "OPTIONAL"
+        },
+        "description": {
+          "type": "string",
+          "title": "OPTIONAL"
+        },
+        "inputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/tesTaskParameter"
+          },
+          "description": "Input files.\nInputs will be downloaded and mounted into the executor container.",
+          "title": "OPTIONAL"
+        },
+        "outputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/tesTaskParameter"
+          },
+          "description": "Output files.\nOutputs will be uploaded from the executor container to long-term storage.",
+          "title": "OPTIONAL"
+        },
+        "resources": {
+          "$ref": "#/definitions/tesResources",
+          "description": "Request that the task be run with these resources.",
+          "title": "OPTIONAL"
+        },
+        "executors": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/tesExecutor"
+          },
+          "description": "A list of executors to be run, sequentially.",
+          "title": "REQUIRED"
+        }
+      },
+      "description": "CreateTaskRequest describes a task to be created and run."
+    },
+    "tesExecutor": {
+      "type": "object",
+      "properties": {
+        "image_name": {
+          "type": "string",
+          "description": "Name of the container image, for example:\nubuntu\nquay.io/aptible/ubuntu\ngcr.io/my-org/my-image\netc...",
+          "title": "REQUIRED"
         },
         "cmd": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "title": "REQUIRED\nThe command to be executed"
+          "description": "The command to be executed.",
+          "title": "REQUIRED"
         },
         "workdir": {
           "type": "string",
-          "title": "OPTIONAL: default docker image directory\nThe working directory that the command will be executed in"
+          "description": "The working directory that the command will be executed in.\nDefaults to the directory set by the container image.",
+          "title": "OPTIONAL"
         },
         "stdin": {
           "type": "string",
-          "title": "OPTIONAL\nPath for supplying input to stdin, blank if none"
+          "description": "Path inside the container to a file which will be piped\nto the command's stdin.",
+          "title": "OPTIONAL"
         },
         "stdout": {
           "type": "string",
-          "title": "OPTIONAL\nPath for stdout recording, blank if not storing to file"
+          "description": "Path inside the container to a file where the command's\nstdout will be written to.",
+          "title": "OPTIONAL"
         },
         "stderr": {
           "type": "string",
-          "title": "OPTIONAL\nPath for stderr recording, blank if not storing to file"
+          "description": "Path inside the container to a file where the command's\nstderr will be written to.",
+          "title": "OPTIONAL"
         },
         "ports": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ga4gh_task_execPorts"
+            "$ref": "#/definitions/tesPorts"
           },
-          "title": "OPTIONAL\nPort to expose from within the container, blank if none"
+          "description": "Port to expose from within the container, blank if none.",
+          "title": "OPTIONAL"
         },
         "environ": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
           },
-          "title": "OPTIONAL\nEnviromental variables to set within the container"
+          "description": "Enviromental variables to set within the container.",
+          "title": "OPTIONAL"
         }
       },
-      "title": "A command line to be executed and the docker container to run it"
+      "description": "Executor describes a command to run, and its environment."
     },
-    "ga4gh_task_execFileLog": {
+    "tesExecutorLog": {
       "type": "object",
       "properties": {
-        "location": {
+        "start_time": {
           "type": "string",
-          "title": "REQUIRED\nlocation in long term storage that the output file was copied to\nis a url specific to the implementing\nsystem. For example s3://my-object-store/file1 or gs://my-bucket/file2 or\nfile:///path/to/my/file"
+          "description": "Time the executor was started, in ISO 8601 format.",
+          "title": "OPTIONAL"
         },
-        "path": {
+        "end_time": {
           "type": "string",
-          "title": "REQUIRED\npath in the machine file system that originated the file"
-        },
-        "size": {
-          "type": "string",
-          "format": "int64",
-          "title": "REQUIRED\nSize of produced file"
-        }
-      },
-      "title": "Log of file output by workflow"
-    },
-    "ga4gh_task_execJob": {
-      "type": "object",
-      "properties": {
-        "jobID": {
-          "type": "string"
-        },
-        "metadata": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "task": {
-          "$ref": "#/definitions/ga4gh_task_execTask"
-        },
-        "state": {
-          "$ref": "#/definitions/ga4gh_task_execState"
-        },
-        "logs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ga4gh_task_execJobLog"
-          }
-        },
-        "outputs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ga4gh_task_execFileLog"
-          },
-          "title": "List of all files copied out to the object store as well as some basic\nmeta-data about them. This is an expanded list, if the task outputs \nlist directories, this record details every individual file"
-        }
-      },
-      "title": "The description of the running instance of a task"
-    },
-    "ga4gh_task_execJobDesc": {
-      "type": "object",
-      "properties": {
-        "jobID": {
-          "type": "string",
-          "title": "REQUIRED"
-        },
-        "state": {
-          "$ref": "#/definitions/ga4gh_task_execState",
-          "title": "REQUIRED"
-        }
-      },
-      "title": "Small description of jobs, returned by server during listing"
-    },
-    "ga4gh_task_execJobID": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "string"
-        }
-      },
-      "title": "ID of an instance of a Task"
-    },
-    "ga4gh_task_execJobListRequest": {
-      "type": "object",
-      "properties": {
-        "projectID": {
-          "type": "string",
-          "description": "OPTIONAL\nThe name of the project to search for pipelines. Caller must have READ access to this project."
-        },
-        "namePrefix": {
-          "type": "string",
-          "description": "OPTIONAL\nPipelines with names that match this prefix should be returned. If unspecified, all pipelines in the project, up to pageSize, will be returned."
-        },
-        "pageSize": {
-          "type": "integer",
-          "format": "int64",
-          "description": "OPTIONAL\nNumber of pipelines to return at once. Defaults to 256, and max is 2048."
-        },
-        "pageToken": {
-          "type": "string",
-          "description": "OPTIONAL\nToken to use to indicate where to start getting results. If unspecified, returns the first page of results."
-        }
-      },
-      "title": "Request listing of jobs tracked by server"
-    },
-    "ga4gh_task_execJobListResponse": {
-      "type": "object",
-      "properties": {
-        "jobs": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ga4gh_task_execJobDesc"
-          }
-        },
-        "nextPageToken": {
-          "type": "string"
-        }
-      },
-      "title": "Return envelope"
-    },
-    "ga4gh_task_execJobLog": {
-      "type": "object",
-      "properties": {
-        "startTime": {
-          "type": "string",
-          "title": "When the command was executed"
-        },
-        "endTime": {
-          "type": "string",
-          "title": "When the command completed"
+          "description": "Time the executor ended, in ISO 8601 format.",
+          "title": "OPTIONAL"
         },
         "stdout": {
           "type": "string",
-          "title": "Sample of stdout (not guaranteed to be entire log)"
+          "description": "Stdout tail.\nThis is not guaranteed to be the entire log.\nImplementations determine the maximum size.",
+          "title": "OPTIONAL"
         },
         "stderr": {
           "type": "string",
-          "title": "Sample of stderr (not guaranteed to be entire log)"
+          "description": "Stderr tail.\nThis is not guaranteed to be the entire log.\nImplementations determine the maximum size.",
+          "title": "OPTIONAL"
         },
-        "exitCode": {
+        "exit_code": {
           "type": "integer",
           "format": "int32",
-          "title": "Exit code of the program"
+          "description": "Exit code.",
+          "title": "REQUIRED"
         },
-        "hostIP": {
+        "host_ip": {
           "type": "string",
-          "title": "ip of worker host"
+          "description": "IP address of host.",
+          "title": "OPTIONAL"
         },
         "ports": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ga4gh_task_execPorts"
+            "$ref": "#/definitions/tesPorts"
           },
-          "title": "ports bound from container to host"
+          "description": "Ports mapped between the container and host.",
+          "title": "OPTIONAL"
         }
-      }
+      },
+      "description": "ExecutorLog describes logging information related to an Executor.",
+      "title": "OUTPUT ONLY"
     },
-    "ga4gh_task_execPorts": {
+    "tesGetTaskRequest": {
+      "type": "object",
+      "properties": {
+        "task_id": {
+          "type": "string",
+          "title": "REQUIRED"
+        }
+      },
+      "description": "GetTaskRequest describes a request to the GetTask endpoint."
+    },
+    "tesListTasksRequest": {
+      "type": "object",
+      "properties": {
+        "project": {
+          "type": "string",
+          "description": "Filter the task list to include tasks in this project.",
+          "title": "OPTIONAL"
+        },
+        "name_prefix": {
+          "type": "string",
+          "description": "Filter the list to include tasks where the name matches this prefix.\nIf unspecified, no task name filtering is done.",
+          "title": "OPTIONAL"
+        },
+        "page_size": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Number of tasks to return in one page.\nMust be less than 2048. Defaults to 256.",
+          "title": "OPTIONAL"
+        },
+        "page_token": {
+          "type": "string",
+          "description": "Page token is used to retrieve the next page of results.\nIf unspecified, returns the first page of results.\nSee ListTasksResponse.next_page_token",
+          "title": "OPTIONAL"
+        }
+      },
+      "description": "ListTasksRequest describes a request to the ListTasks service endpoint."
+    },
+    "tesListTasksResponse": {
+      "type": "object",
+      "properties": {
+        "tasks": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/tesTaskDesc"
+          },
+          "description": "List of lightweight task descriptions.",
+          "title": "REQUIRED"
+        },
+        "next_page_token": {
+          "type": "string",
+          "description": "Token used to return the next page of results.\nSee TaskListRequest.next_page_token",
+          "title": "OPTIONAL"
+        }
+      },
+      "description": "ListTasksResponse describes a response from the ListTasks endpoint.",
+      "title": "OUTPUT ONLY"
+    },
+    "tesOutputFileLog": {
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "URL of the file in storage, e.g. s3://bucket/file.txt",
+          "title": "REQUIRED"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path of the file inside the container.",
+          "title": "REQUIRED"
+        },
+        "size": {
+          "type": "string",
+          "format": "int64",
+          "description": "Size of the file in bytes.",
+          "title": "REQUIRED"
+        }
+      },
+      "description": "OutputFileLog describes a single output file. This describes\nfile details after the task has completed successfully,\nfor logging purposes.",
+      "title": "OUTPUT ONLY"
+    },
+    "tesPorts": {
       "type": "object",
       "properties": {
         "container": {
           "type": "integer",
-          "format": "int32",
-          "title": "REQUIRED \nExposed port on container"
+          "format": "int64",
+          "description": "Port number opened inside the container.",
+          "title": "REQUIRED"
         },
         "host": {
           "type": "integer",
-          "format": "int32",
-          "title": "OPTIONAL \nMust be greater than 1024;\nDefaults to 0"
+          "format": "int64",
+          "description": "Port number opened on the host. Must be greater than 1024.\nDefaults to 0, which assigns a random port on the host.",
+          "title": "OPTIONAL"
         }
       },
-      "title": "host to container port mappings"
+      "description": "Ports describes the port mapping between the container and host."
     },
-    "ga4gh_task_execResources": {
+    "tesResources": {
       "type": "object",
       "properties": {
-        "minimumCpuCores": {
+        "minimum_cpu_cores": {
           "type": "integer",
           "format": "int64",
-          "title": "OPTIONAL default 1\nMinimum number of CPUs"
+          "description": "Minimum number of CPUs\nDefault 1",
+          "title": "OPTIONAL"
         },
         "preemptible": {
           "type": "boolean",
           "format": "boolean",
-          "title": "Can schedule on resource that resource that can be preempted, like AWS Spot Instances\nOPTIONAL default false"
+          "description": "Is the task allowed to run on preemptible compute instances (e.g. AWS Spot)?",
+          "title": "OPTIONAL"
         },
-        "minimumRamGb": {
+        "minimum_ram_gb": {
           "type": "number",
           "format": "double",
-          "title": "REQUIRED\nMinimum RAM required"
+          "description": "Minimum RAM required in gigabytes (GB)",
+          "title": "OPTIONAL"
         },
         "volumes": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ga4gh_task_execVolume"
+            "$ref": "#/definitions/tesVolume"
           },
-          "title": "REQUIRED\nVolumes to be mounted into the docker container"
+          "description": "Volumes to be mounted into the container.",
+          "title": "OPTIONAL"
         },
         "zones": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "title": "OPTIONAL\noptional scheduling information for systems where multiple compute zones are avalible"
+          "description": "Request that the task be run in these compute zones.",
+          "title": "OPTIONAL"
         }
-      }
+      },
+      "description": "Resources describes the resources requested by a task."
     },
-    "ga4gh_task_execServiceInfo": {
+    "tesServiceInfo": {
       "type": "object",
       "properties": {
-        "storageConfig": {
+        "storage_config": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
           },
-          "title": "System specific key/value pairs\nExample for a shared file system based storage system:\nstorageType=sharedFile, baseDir=/path/to/shared/directory"
+          "description": "System specific key/value pairs\nExample for a shared file system based storage system:\nstorageType=sharedFile, baseDir=/path/to/shared/directory",
+          "title": "OPTIONAL"
         }
       },
-      "title": "Information about Task Execution Service\nMay include information related (but not limited to)\nresource availability and storage system information"
+      "description": "ServiceInfo describes information about the service,\nsuch as storage details, resource availability,\nand other documentation.",
+      "title": "OUTPUT ONLY"
     },
-    "ga4gh_task_execServiceInfoRequest": {
+    "tesServiceInfoRequest": {
       "type": "object",
-      "title": "Blank request message for service request"
+      "description": "ServiceInfoRequest describes a request to the ServiceInfo endpoint."
     },
-    "ga4gh_task_execState": {
+    "tesState": {
       "type": "string",
       "enum": [
-        "Unknown",
-        "Queued",
-        "Running",
-        "Paused",
-        "Complete",
-        "Error",
-        "SystemError",
-        "Canceled",
-        "Initializing"
+        "UNKNOWN",
+        "QUEUED",
+        "INITIALIZING",
+        "RUNNING",
+        "PAUSED",
+        "COMPLETE",
+        "ERROR",
+        "SYSTEM_ERROR",
+        "CANCELED"
       ],
-      "default": "Unknown"
+      "default": "UNKNOWN",
+      "description": "Task states.",
+      "title": "OUTPUT ONLY"
     },
-    "ga4gh_task_execTask": {
+    "tesTask": {
       "type": "object",
       "properties": {
-        "name": {
+        "task_id": {
           "type": "string",
-          "title": "OPTIONAL\nuser name for task"
+          "title": "REQUIRED"
         },
-        "projectID": {
-          "type": "string",
-          "title": "OPTIONAL\nparameter for execution engine to define/store group information"
+        "metadata": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "title": "REQUIRED"
         },
-        "description": {
-          "type": "string",
-          "title": "OPTIONAL\nfree text description of task"
+        "task": {
+          "$ref": "#/definitions/tesTask",
+          "title": "REQUIRED"
         },
-        "inputs": {
+        "state": {
+          "$ref": "#/definitions/tesState",
+          "title": "REQUIRED"
+        },
+        "logs": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ga4gh_task_execTaskParameter"
+            "$ref": "#/definitions/tesExecutorLog"
           },
-          "title": "REQUIRED\nFiles to be copied into system before tasks"
+          "title": "REQUIRED"
         },
         "outputs": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ga4gh_task_execTaskParameter"
+            "$ref": "#/definitions/tesOutputFileLog"
           },
-          "title": "REQUIRED\nFiles to be copied out of the system after tasks"
-        },
-        "resources": {
-          "$ref": "#/definitions/ga4gh_task_execResources",
-          "title": "REQUIRED\nDefine required system resources to run job"
-        },
-        "docker": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ga4gh_task_execDockerExecutor"
-          },
-          "title": "REQUIRED\nAn array of docker executions that will be run sequentially"
+          "description": "Information about all output files. Directory outputs are\nflattened into separate items.",
+          "title": "REQUIRED"
         }
       },
-      "title": "The description of a task to be run"
+      "description": "Task describes an instance of a task.",
+      "title": "OUTPUT ONLY"
     },
-    "ga4gh_task_execTaskParameter": {
+    "tesTaskDesc": {
+      "type": "object",
+      "properties": {
+        "task_id": {
+          "type": "string",
+          "title": "REQUIRED"
+        },
+        "state": {
+          "$ref": "#/definitions/tesState",
+          "title": "REQUIRED"
+        }
+      },
+      "description": "TaskDesc is a lightweight description of a task, which is returned\nby the ListTasks endpoint.",
+      "title": "OUTPUT ONLY"
+    },
+    "tesTaskParameter": {
       "type": "object",
       "properties": {
         "name": {
           "type": "string",
-          "title": "OPTIONAL\nname of the parameter"
+          "title": "OPTIONAL"
         },
         "description": {
           "type": "string",
-          "title": "OPTIONAL\nText description"
+          "title": "OPTIONAL"
         },
-        "location": {
+        "url": {
           "type": "string",
-          "title": "REQUIRED\nlocation in long term storage, is a url specific to the implementing\nsystem. For example s3://my-object-store/file1 or gs://my-bucket/file2 or\nfile:///path/to/my/file"
+          "description": "URL in long term storage, for example:\ns3://my-object-store/file1\ngs://my-bucket/file2\nfile:///path/to/my/file\n/path/to/my/file\netc...",
+          "title": "REQUIRED"
         },
         "path": {
           "type": "string",
-          "title": "REQUIRED\npath in the machine file system. Note, this MUST be a path that exists\nwithin one of the defined volumes\nIf the file is mounted in a volume that is mounted read/write the file must\nbe accessable to processes in the container. Optimizations, suc as hard linking\nto a source file, or providing a streaming input from a FUSE mount should only\nbe done if the volume is mounted as read only"
+          "description": "Path of the file inside the container.",
+          "title": "REQUIRED"
         },
         "class": {
           "type": "string",
-          "title": "REQUIRED\nType of data, \"File\" or \"Directory\"\nif used for an output all the files in the directory\nwill be copied to the storage location"
+          "description": "Type of the file: \"File\" or \"Directory\".",
+          "title": "REQUIRED"
         },
         "create": {
           "type": "boolean",
           "format": "boolean",
-          "title": "OPTIONAL: default false\nif the parameter is an output, should the element be created before executing\nthe command. For example if saving the working directory as an output,\nthe directory needs to exist before the command is called. If false, it is\nassumed that the user will create the element as a part of the operation"
+          "description": "If true, this path will be created before the task starts running.\nThis helps tasks create output directories which the task will\nwrite to.",
+          "title": "OPTIONAL"
         }
       },
-      "title": "Parameters for Task"
+      "description": "TaskParameter describes input and output files for a Task."
     },
-    "ga4gh_task_execVolume": {
+    "tesVolume": {
       "type": "object",
       "properties": {
         "name": {
           "type": "string",
-          "title": "OPTIONAL\nName of attached volume"
+          "title": "OPTIONAL"
         },
-        "sizeGb": {
+        "size_gb": {
           "type": "number",
           "format": "double",
-          "title": "REQUIRED\nMinimum size"
+          "description": "Requested disk size in gigabytes (GB)",
+          "title": "REQUIRED"
         },
-        "mountPoint": {
+        "mount_point": {
           "type": "string",
-          "title": "REQUIRED\nmount point for volume inside the docker container"
+          "description": "Path inside the container that the volume will be mounted to.",
+          "title": "REQUIRED"
         }
       },
-      "description": "Attached volume request."
+      "description": "Volume describes a volume (i.e. directory) which will be\nmounted into an executor/container."
     }
   }
 }

--- a/swagger/proto/task_execution.swagger.json
+++ b/swagger/proto/task_execution.swagger.json
@@ -517,8 +517,8 @@
           },
           "title": "REQUIRED"
         },
-        "task": {
-          "$ref": "#/definitions/tesTask",
+        "request": {
+          "$ref": "#/definitions/tesCreateTaskRequest",
           "title": "REQUIRED"
         },
         "state": {


### PR DESCRIPTION
I did a thorough pass over the protobuf to proofread and clean things up. Most of this is documentation and style changes, but there are some bigger name changes as well.

One thing was to rename message fields to follow the protobuf style guide:
https://developers.google.com/protocol-buffers/docs/style

The big change was to rename Job to Task as follows:
```
Task -> CreateTaskRequest
Job -> Task
RunTask() -> CreateTask()
```
The argument is:
1) Job vs Task has confused just about everyone at some point
2) This is the **Task** execution schema, after all
3) This allows the service endpoints to better follow Google's API guide
4) The result is actually pretty nice, IMO

One concern was that CreateTaskRequest would be too verbose. In reality, at least for Funnel, this will show up once or twice in the codebase, and will immediately be assigned to a shorter variable name, e.g. `req := CreateTaskRequest{}`, so I don't think brevity is worth the cost of confusion.

The Google API Design Guide inspired some of the changes here, because it is a clear and very well thought out convention, with a lot of experience behind it.
https://cloud.google.com/apis/design/

Some other renames:
JobLog -> ExecutorLog
FileLog -> OutputFileLog
package ga4gh_task_exec -> package tes
JobListRequest -> ListTasksRequest
ServiceInfoResponse -> ServiceInfo
GetTask() returns a Task
CreateTask() returns a Task
CancelTask() uses HTTP POST instead of DELETE
The HTTP endpoints for GetServiceInfo and CancelTask changed