### PR TITLE
Redefining volumes

### DIFF
--- a/proto/task_execution.proto
+++ b/proto/task_execution.proto
@@ -21,12 +21,8 @@ message TaskParameter {
   //file:///path/to/my/file
   string url = 3;
   //REQUIRED
-  //path in the machine file system. Note, this MUST be a path that exists
-  //within one of the defined volumes
-  //If the file is mounted in a volume that is mounted read/write the file must
-  //be accessable to processes in the container. Optimizations, suc as hard linking
-  //to a source file, or providing a streaming input from a FUSE mount should only
-  //be done if the volume is mounted as read only
+  //path in the executor file system.
+  //All inputs are mounted as read-only.
   string path = 4;
   //REQUIRED
   //Type of data, "File" or "Directory"
@@ -80,19 +76,6 @@ message Executor {
   map<string,string> environ = 8;
 }
 
-//Attached volume request.
-message Volume {
-  //OPTIONAL
-  //Name of attached volume
-  string name = 1;
-  //REQUIRED
-  //Minimum size
-  double sizeGb = 2;
-  //REQUIRED
-  //mount point for volume
-  string mountPoint = 6;
-}
-
 message Resources {
   //OPTIONAL default 1
   //Minimum number of CPUs
@@ -103,9 +86,9 @@ message Resources {
   //REQUIRED
   //Minimum RAM required
   double minimumRamGb = 3;
-  //REQUIRED
-  //Volumes to be mounted
-  repeated Volume volumes = 4;
+  //OPTIONAL
+  //Requested disk size in GB
+  double diskGb = 4;
   //OPTIONAL
   //optional scheduling information for systems where multiple compute zones are avalible
   repeated string zones = 5;
@@ -134,6 +117,11 @@ message Task {
   //REQUIRED
   //A list of executors that will be run sequentially
   repeated Executor executors = 8;
+  //OPTIONAL
+  //A list of additional volumes 
+  //These are shared between executors. Volumes for the executor work dir,
+  //inputs and outputs will be inferred and do not need to be defined here. 
+  repeated string volumes = 9;
 }
 
 //Request listing of jobs tracked by server

--- a/swagger/proto/task_execution.swagger.json
+++ b/swagger/proto/task_execution.swagger.json
@@ -69,7 +69,7 @@
           "200": {
             "description": "",
             "schema": {
-              "$ref": "#/definitions/ga4gh_task_execJobID"
+              "$ref": "#/definitions/ga4gh_task_execRunTaskResponse"
             }
           }
         },
@@ -96,7 +96,7 @@
           "200": {
             "description": "",
             "schema": {
-              "$ref": "#/definitions/ga4gh_task_execServiceInfo"
+              "$ref": "#/definitions/ga4gh_task_execServiceInfoResponse"
             }
           }
         },
@@ -105,7 +105,7 @@
         ]
       }
     },
-    "/v1/jobs/{value}": {
+    "/v1/jobs/{jobID}": {
       "get": {
         "summary": "Get info about a running task",
         "operationId": "GetJob",
@@ -113,13 +113,13 @@
           "200": {
             "description": "",
             "schema": {
-              "$ref": "#/definitions/ga4gh_task_execJob"
+              "$ref": "#/definitions/ga4gh_task_execGetJobResponse"
             }
           }
         },
         "parameters": [
           {
-            "name": "value",
+            "name": "jobID",
             "in": "path",
             "required": true,
             "type": "string"
@@ -136,13 +136,13 @@
           "200": {
             "description": "",
             "schema": {
-              "$ref": "#/definitions/ga4gh_task_execJobID"
+              "$ref": "#/definitions/ga4gh_task_execCancelJobResponse"
             }
           }
         },
         "parameters": [
           {
-            "name": "value",
+            "name": "jobID",
             "in": "path",
             "required": true,
             "type": "string"
@@ -155,12 +155,23 @@
     }
   },
   "definitions": {
-    "ga4gh_task_execDockerExecutor": {
+    "ga4gh_task_execCancelJobRequest": {
+      "type": "object",
+      "properties": {
+        "jobID": {
+          "type": "string"
+        }
+      }
+    },
+    "ga4gh_task_execCancelJobResponse": {
+      "type": "object"
+    },
+    "ga4gh_task_execExecutor": {
       "type": "object",
       "properties": {
         "imageName": {
           "type": "string",
-          "title": "REQUIRED\nDocker Image name"
+          "title": "REQUIRED\nImage name"
         },
         "cmd": {
           "type": "array",
@@ -171,7 +182,7 @@
         },
         "workdir": {
           "type": "string",
-          "title": "OPTIONAL: default docker image directory\nThe working directory that the command will be executed in"
+          "title": "OPTIONAL: default image directory\nThe working directory that the command will be executed in"
         },
         "stdin": {
           "type": "string",
@@ -200,14 +211,14 @@
           "title": "OPTIONAL\nEnviromental variables to set within the container"
         }
       },
-      "title": "A command line to be executed and the docker container to run it"
+      "title": "Executor executes a task"
     },
     "ga4gh_task_execFileLog": {
       "type": "object",
       "properties": {
-        "location": {
+        "url": {
           "type": "string",
-          "title": "REQUIRED\nlocation in long term storage that the output file was copied to\nis a url specific to the implementing\nsystem. For example s3://my-object-store/file1 or gs://my-bucket/file2 or\nfile:///path/to/my/file"
+          "title": "REQUIRED\nurl of long term storage that the output file was copied to\nis a url specific to the implementing\nsystem. For example s3://my-object-store/file1 or gs://my-bucket/file2 or\nfile:///path/to/my/file"
         },
         "path": {
           "type": "string",
@@ -220,6 +231,22 @@
         }
       },
       "title": "Log of file output by workflow"
+    },
+    "ga4gh_task_execGetJobRequest": {
+      "type": "object",
+      "properties": {
+        "jobID": {
+          "type": "string"
+        }
+      }
+    },
+    "ga4gh_task_execGetJobResponse": {
+      "type": "object",
+      "properties": {
+        "job": {
+          "$ref": "#/definitions/ga4gh_task_execJob"
+        }
+      }
     },
     "ga4gh_task_execJob": {
       "type": "object",
@@ -269,15 +296,6 @@
       },
       "title": "Small description of jobs, returned by server during listing"
     },
-    "ga4gh_task_execJobID": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "string"
-        }
-      },
-      "title": "ID of an instance of a Task"
-    },
     "ga4gh_task_execJobListRequest": {
       "type": "object",
       "properties": {
@@ -321,11 +339,11 @@
       "properties": {
         "startTime": {
           "type": "string",
-          "title": "When the command was executed"
+          "title": "When the command was executed in ISO 8601 format"
         },
         "endTime": {
           "type": "string",
-          "title": "When the command completed"
+          "title": "When the command completed in ISO 8601 format"
         },
         "stdout": {
           "type": "string",
@@ -358,12 +376,12 @@
       "properties": {
         "container": {
           "type": "integer",
-          "format": "int32",
+          "format": "int64",
           "title": "REQUIRED \nExposed port on container"
         },
         "host": {
           "type": "integer",
-          "format": "int32",
+          "format": "int64",
           "title": "OPTIONAL \nMust be greater than 1024;\nDefaults to 0"
         }
       },
@@ -387,12 +405,10 @@
           "format": "double",
           "title": "REQUIRED\nMinimum RAM required"
         },
-        "volumes": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ga4gh_task_execVolume"
-          },
-          "title": "REQUIRED\nVolumes to be mounted into the docker container"
+        "diskGb": {
+          "type": "number",
+          "format": "double",
+          "title": "OPTIONAL\nRequested disk size in GB"
         },
         "zones": {
           "type": "array",
@@ -403,7 +419,20 @@
         }
       }
     },
-    "ga4gh_task_execServiceInfo": {
+    "ga4gh_task_execRunTaskResponse": {
+      "type": "object",
+      "properties": {
+        "jobID": {
+          "type": "string"
+        }
+      },
+      "title": "ID of an instance of a Task"
+    },
+    "ga4gh_task_execServiceInfoRequest": {
+      "type": "object",
+      "title": "Blank request message for service request"
+    },
+    "ga4gh_task_execServiceInfoResponse": {
       "type": "object",
       "properties": {
         "storageConfig": {
@@ -415,10 +444,6 @@
         }
       },
       "title": "Information about Task Execution Service\nMay include information related (but not limited to)\nresource availability and storage system information"
-    },
-    "ga4gh_task_execServiceInfoRequest": {
-      "type": "object",
-      "title": "Blank request message for service request"
     },
     "ga4gh_task_execState": {
       "type": "string",
@@ -468,12 +493,19 @@
           "$ref": "#/definitions/ga4gh_task_execResources",
           "title": "REQUIRED\nDefine required system resources to run job"
         },
-        "docker": {
+        "executors": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/ga4gh_task_execDockerExecutor"
+            "$ref": "#/definitions/ga4gh_task_execExecutor"
           },
-          "title": "REQUIRED\nAn array of docker executions that will be run sequentially"
+          "title": "REQUIRED\nA list of executors that will be run sequentially"
+        },
+        "volumes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "OPTIONAL\nA list of additional volumes \nThese are shared between executors. Volumes for the executor work dir,\ninputs and outputs will be inferred and do not need to be defined here."
         }
       },
       "title": "The description of a task to be run"
@@ -489,17 +521,17 @@
           "type": "string",
           "title": "OPTIONAL\nText description"
         },
-        "location": {
+        "url": {
           "type": "string",
-          "title": "REQUIRED\nlocation in long term storage, is a url specific to the implementing\nsystem. For example s3://my-object-store/file1 or gs://my-bucket/file2 or\nfile:///path/to/my/file"
+          "title": "REQUIRED\nurl in long term storage, is a url specific to the implementing\nsystem. For example s3://my-object-store/file1 or gs://my-bucket/file2 or\nfile:///path/to/my/file"
         },
         "path": {
           "type": "string",
-          "title": "REQUIRED\npath in the machine file system. Note, this MUST be a path that exists\nwithin one of the defined volumes\nIf the file is mounted in a volume that is mounted read/write the file must\nbe accessable to processes in the container. Optimizations, suc as hard linking\nto a source file, or providing a streaming input from a FUSE mount should only\nbe done if the volume is mounted as read only"
+          "description": "REQUIRED\npath in the executor file system.\nAll inputs are mounted as read-only."
         },
         "class": {
           "type": "string",
-          "title": "REQUIRED\nType of data, \"File\" or \"Directory\"\nif used for an output all the files in the directory\nwill be copied to the storage location"
+          "title": "REQUIRED\nType of data, \"File\" or \"Directory\"\nif used for an output all the files in the directory\nwill be copied to the storage url"
         },
         "create": {
           "type": "boolean",
@@ -508,25 +540,6 @@
         }
       },
       "title": "Parameters for Task"
-    },
-    "ga4gh_task_execVolume": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string",
-          "title": "OPTIONAL\nName of attached volume"
-        },
-        "sizeGb": {
-          "type": "number",
-          "format": "double",
-          "title": "REQUIRED\nMinimum size"
-        },
-        "mountPoint": {
-          "type": "string",
-          "title": "REQUIRED\nmount point for volume inside the docker container"
-        }
-      },
-      "description": "Attached volume request."
     }
   }
 }


### PR DESCRIPTION
This PR:
* removes the Volumes message type
* moves requested disk size to the Resources
* adds a volumes field to the Task message
* clarifies documentation so state that all input files and directories will be mounted as read-only. 

Since the mounted paths of inputs and outputs are explicitly provided, we do not need to duplicate this information in the Volume message. The same is true regarding the working dir. 

Requested free disk space is now part of Resources. It didn't make much sense where it was before. 

The volumes field in the Task message refers to locations in the Executors where data may be written, but is not explicitly an output directory.  One could use this to share temporary data between Executor steps. 