### PR TITLE
Fixed cancel http endpoint

### DIFF
--- a/task_execution.proto
+++ b/task_execution.proto
@@ -503,7 +503,6 @@ service TaskService {
   rpc CancelTask(CancelTaskRequest) returns (CancelTaskResponse) {
     option (google.api.http) = {
       post: "/v1/tasks/{id}:cancel"
-      body: "*"
     };
   }
 

--- a/task_execution.swagger.json
+++ b/task_execution.swagger.json
@@ -174,14 +174,6 @@
             "in": "path",
             "required": true,
             "type": "string"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/tesCancelTaskRequest"
-            }
           }
         ],
         "tags": [


### PR DESCRIPTION
Having `body: "*"` in the service definition for the cancel endpoint had unintended consequences. 

This PR allows you to cancel a task via:

`curl -X POST http://localhost:8000/v1/tasks/{id}:cancel`

rather than

`curl -X -d '{}' POST http://localhost:8000/v1/tasks/{id}:cancel`

as was required by the original definition. 
