### PR TITLE
System logs field

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The return value will be a minimal description of the task state.
 To get more information, you can change the task view using the `view` URL query parameter.  
 
 The `basic` view will include all task fields except a few which might be
-large strings (stdout/err logging, input parameter contents).
+large strings (stdout/err/system logging, input parameter contents).
 
 ```HTTP
 GET /v1/tasks/task-1234?view=BASIC
@@ -115,7 +115,7 @@ GET /v1/tasks/task-1234?view=BASIC
 { "id": "task-1234", "state": "RUNNING", "name": "MD5 example", etc... }
 ```
 
-The `full` view includes stdout/err logs and full input parameters:
+The `full` view includes stdout/err/system logs and full input parameters:
 
 ```HTTP
 GET /v1/tasks/task-1234?view=FULL

--- a/task_execution.proto
+++ b/task_execution.proto
@@ -291,6 +291,8 @@ message TaskLog {
   // For example, the system may include the name of the host
   // where the task is executing, an error message that caused
   // a SYSTEM_ERROR state (e.g. disk is full), etc.
+  //
+  // System logs are only included in the FULL task view.
   repeated string system_logs = 6;
 }
 
@@ -469,6 +471,7 @@ enum TaskView {
   //   Task.ExecutorLog.stdout
   //   Task.ExecutorLog.stderr
   //   Input.content
+  //   TaskLog.system_logs
   BASIC = 1;
 
   // Task message includes all fields.

--- a/task_execution.proto
+++ b/task_execution.proto
@@ -279,6 +279,11 @@ message TaskLog {
   // Information about all output files. Directory outputs are
   // flattened into separate items.
   repeated OutputFileLog outputs = 5;
+  
+  // OPTIONAL
+  //
+  // Optional system logs.
+  repeated string syslogs = 6;
 }
 
 // OUTPUT ONLY

--- a/task_execution.proto
+++ b/task_execution.proto
@@ -282,8 +282,16 @@ message TaskLog {
   
   // OPTIONAL
   //
-  // Optional system logs.
-  repeated string syslogs = 6;
+  // System logs are any logs the system decides are relevant,
+  // which are not tied directly to an Executor process.
+  // Content is implementation specific: format, size, etc.
+  //
+  // System logs may be collected here to provide convenient access.
+  //
+  // For example, the system may include the name of the host
+  // where the task is executing, an error message that caused
+  // a SYSTEM_ERROR state (e.g. disk is full), etc.
+  repeated string system_logs = 6;
 }
 
 // OUTPUT ONLY


### PR DESCRIPTION
In Funnel, we've found that there are a lot of logs coming from the system and not the executor (container) that are important: an error message from the object store client, an error message from the system about a disk being full, a docker run command, etc. We've been avoiding adding this to TES and putting it in separate endpoints, or accessing these logs via external systems such as rsyslog or Kibana, but I think it's worth proposing here. It's an optional field, and in the logs message, so not much overhead to implementations.