### PR TITLE
suggestions for more consistent field names in Executor

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ an MD5 checksum on an input file and uploads the output:
     },
     "executors" : [
       {
-        "image_name" : "ubuntu",
-        "cmd" : ["md5sum", "/container/input"],
+        "image" : "ubuntu",
+        "command" : ["md5sum", "/container/input"],
         "stdout" : "/container/output",
         "stderr" : "/container/stderr",
         "workdir": "/tmp"
@@ -73,8 +73,8 @@ A minimal version of the same task, including only the required fields looks lik
     ],
     "executors" : [
       {
-        "image_name" : "ubuntu",
-        "cmd" : ["md5sum", "/container/input"],
+        "image" : "ubuntu",
+        "command" : ["md5sum", "/container/input"],
         "stdout" : "/container/output"
       }
     ]

--- a/task_execution.proto
+++ b/task_execution.proto
@@ -142,13 +142,13 @@ message Executor {
   // quay.io/aptible/ubuntu
   // gcr.io/my-org/my-image
   // etc...
-  string image_name = 1;
+  string image = 1;
 
   // REQUIRED
   //
   // A sequence of program arguments to execute, where the first argument
   // is the program to execute (i.e. argv).
-  repeated string cmd = 2;
+  repeated string command = 2;
 
   // OPTIONAL
   //
@@ -186,7 +186,7 @@ message Executor {
   // OPTIONAL
   //
   // Enviromental variables to set within the container.
-  map<string,string> environ = 8;
+  map<string,string> env = 8;
 }
 
 // Resources describes the resources requested by a task.


### PR DESCRIPTION
Going through the schema and implementing a remote interface for funnel, all of the field names are so concise and elegant that these three field names stuck out.

I am proposing three changes:

* image_name --> image

Most of the other fields throughout the schema are single names, and the word `image` does not need to be disambiguated with any other fields in the schema, so this seems like the natural choice.

* cmd --> command

The schema is refreshingly light on abbreviated names to the point where this one stands out. Why not just `command`?

* environ --> env

This one is funny because it is really just a different abbreviation of `environment`. I would almost prefer `environment` since it is nice to be clear, but we have such a long-standing tradition of using the three letters ENV to stand for the environment (even the bash program called `env`) that I think this one makes sense.

Open to all thoughts and ideas on this.