### PR TITLE
Rename ERROR -> EXECUTOR_ERROR

### DIFF
--- a/task_execution.proto
+++ b/task_execution.proto
@@ -333,7 +333,7 @@ enum State {
   // but this is not required.
   PAUSED = 4;
   COMPLETE = 5;
-  ERROR = 6;
+  EXECUTOR_ERROR = 6;
   SYSTEM_ERROR = 7;
   CANCELED = 8;
 }


### PR DESCRIPTION
I think this makes it much clearer that this state only comes from a failed Executor process. 