### PR TITLE
Remove paused (or else define it more clearly)

### DIFF
--- a/task_execution.proto
+++ b/task_execution.proto
@@ -329,9 +329,6 @@ enum State {
   QUEUED = 1;
   INITIALIZING = 2;
   RUNNING = 3;
-  // An implementation *may* have the ability to pause a task,
-  // but this is not required.
-  PAUSED = 4;
   COMPLETE = 5;
   ERROR = 6;
   SYSTEM_ERROR = 7;


### PR DESCRIPTION
This seems like a poorly defined carryover from the Google Genomics API. There's little/no explanation of the behavior of pausing. Can a user pause/unpause? Is pausing controlled solely by the system? If so, does the user need to know that the task is paused?

Not necessarily against the concept of pausing, just trying to cut out the fuzzy parts of the spec until they're clearly defined.
