### PR TITLE
Remove project fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ an MD5 checksum on an input file and uploads the output:
 {
     "name":        "MD5 example",
     "description": "Task which runs md5sum on the input file.",
-    "project":     "tes-example-project-id",
     "tags": {
       "custom-tag": "tag-value"
     },

--- a/task_execution.proto
+++ b/task_execution.proto
@@ -20,12 +20,6 @@ message Task {
   string name = 3;
 
   // OPTIONAL
-  //
-  // Describes the project this task is associated with.
-  // Commonly used for billing on cloud providers (AWS, Google Cloud, etc).
-  string project = 4;
-
-  // OPTIONAL
   string description = 5;
 
   // OPTIONAL
@@ -364,11 +358,6 @@ message GetTaskRequest {
 
 // ListTasksRequest describes a request to the ListTasks service endpoint.
 message ListTasksRequest {
-
-  // OPTIONAL
-  //
-  // Filter the task list to include tasks in this project.
-  string project = 1;
 
   // OPTIONAL
   //


### PR DESCRIPTION
The `project` field is underspecified – is it required to be a cloud project ID? Or just more metadata? Or both? It could be defined via the `tags` field, which would make it simpler to filter via `ListTasks` and might fit to #84 which uses `tags` for cloud/deployment  specific resource requests.