### PR TITLE
Clarify Executor.stdout/err docs and implementation requirements.

### DIFF
--- a/task_execution.proto
+++ b/task_execution.proto
@@ -267,16 +267,28 @@ message ExecutorLog {
 
   // OPTIONAL
   //
-  // Stdout tail.
-  // This is not guaranteed to be the entire log.
-  // Implementations determine the maximum size.
+  // Stdout content.
+  //
+  // This is meant for convenience. No guarantees are made about the content.
+  // Implementations may chose different approaches: only the head, only the tail,
+  // a URL reference only, etc.
+  //
+  // In order to capture the full stdout users should set Executor.stdout
+  // to a container file path, and use Task.outputs to upload that file
+  // to permanent storage.
   string stdout = 4;
 
   // OPTIONAL
   //
-  // Stderr tail.
-  // This is not guaranteed to be the entire log.
-  // Implementations determine the maximum size.
+  // Stderr content.
+  //
+  // This is meant for convenience. No guarantees are made about the content.
+  // Implementations may chose different approaches: only the head, only the tail,
+  // a URL reference only, etc.
+  //
+  // In order to capture the full stderr users should set Executor.stderr
+  // to a container file path, and use Task.outputs to upload that file
+  // to permanent storage.
   string stderr = 5;
 
   // REQUIRED


### PR DESCRIPTION
While developing Funnel, we've found that ensuring that these logs are reliably the correct tail of the content is tricky and feels like an unnecessary burden to implementors. I'm proposing we remove the requirement of the tail, and free up implementations to do what works best for them and their users. There is a fallback of writing the stdout/err to a file and uploading that file to permanent storage, as a way to consistently guarantee you get the full content.