### PR TITLE
Clarify volumes docs.

### DIFF
--- a/task_execution.proto
+++ b/task_execution.proto
@@ -53,9 +53,17 @@ message Task {
 
   // OPTIONAL
   //
-  // Declared volumes.
-  // Volumes are shared between executors. Volumes for inputs and outputs are 
-  // inferred and should not be declared here.
+  // Volumes are directories which may be used to share data between
+  // Executors. Volumes are initialized as empty directories by the
+  // system when the task starts and are mounted at the same path
+  // in each Executor.
+  //
+  // For example, given a volume defined at "/vol/A",
+  // executor 1 may write a file to "/vol/A/exec1.out.txt", then
+  // executor 2 may read from that file.
+  //
+  // (Essentially, this translates to a `docker run -v` flag where
+  // the container path is the same for each executor).
   repeated string volumes = 10;
 
   // OPTIONAL


### PR DESCRIPTION
#64 and #79 both comment on understandable confusion around the volumes field. This attempts to add more docs around it, but maybe it's still not enough. This is a confusing feature that seems to arise from needing to stitch together multiple container filesystems.

Would love feedback from @mbookman and @erikvdbergh on this one.