### PR TITLE
remove paused state

### DIFF
--- a/task_execution.proto
+++ b/task_execution.proto
@@ -372,11 +372,6 @@ enum State {
   // has been started.
   RUNNING = 3;
 
-  // The task is paused.
-  //
-  // An implementation may have the ability to pause a task, but this is not required.
-  PAUSED = 4;
-
   // The task has completed running. Executors have exited without error
   // and output files have been successfully uploaded.
   COMPLETE = 5;


### PR DESCRIPTION
closes #99 

We've flip-flopped on this a bit, but I'm in favor of removing things from the spec that no one is currently using and no one currently has a plan or specification for how to use.

If someone has a robust plan for how tasks can be paused, we can add this back.