### PR TITLE
remove executors

### DIFF
--- a/task_execution.proto
+++ b/task_execution.proto
@@ -25,13 +25,13 @@ message Task {
   // OPTIONAL
   //
   // Input files.
-  // Inputs will be downloaded and mounted into the executor container.
+  // Inputs will be downloaded and mounted into the container.
   repeated Input inputs = 6;
 
   // OPTIONAL
   //
   // Output files.
-  // Outputs will be uploaded from the executor container to long-term storage.
+  // Outputs will be uploaded from the container to long-term storage.
   repeated Output outputs = 7;
 
   // OPTIONAL
@@ -39,25 +39,18 @@ message Task {
   // Request that the task be run with these resources.
   Resources resources = 8;
 
-  // REQUIRED
-  //
-  // A list of executors to be run, sequentially. Execution stops
-  // on the first error.
-  repeated Executor executors = 9;
-
   // OPTIONAL
   //
-  // Volumes are directories which may be used to share data between
-  // Executors. Volumes are initialized as empty directories by the
-  // system when the task starts and are mounted at the same path
-  // in each Executor.
+  // Volumes declare directories which the task expects to write to.
+  // Volumes are initialized as empty directories by the system when
+  // the task starts.
   //
-  // For example, given a volume defined at "/vol/A",
-  // executor 1 may write a file to "/vol/A/exec1.out.txt", then
-  // executor 2 may read from that file.
+  // This isn't always necessary. An implementation may decide to infer
+  // volumes from the workdir, inputs, outputs, or any defaults it provide.
+  // Also, a Docker container definition may define volumes itself, e.g.
+  // by using the VOLUME command in a Dockerfile.
   //
-  // (Essentially, this translates to a `docker run -v` flag where
-  // the container path is the same for each executor).
+  // Essentially, this translates to a `docker run -v /my-volume ...` flag.
   repeated string volumes = 10;
 
   // OPTIONAL
@@ -77,6 +70,50 @@ message Task {
   // Date + time the task was created, in RFC 3339 format.
   // This is set by the system, not the client.
   string creation_time = 13;
+
+  // REQUIRED
+  //
+  // Name of the container image, for example:
+  // ubuntu
+  // quay.io/aptible/ubuntu
+  // gcr.io/my-org/my-image
+  // etc...
+  string image = 1;
+
+  // REQUIRED
+  //
+  // A sequence of program arguments to execute, where the first argument
+  // is the program to execute (i.e. argv).
+  repeated string command = 2;
+
+  // OPTIONAL
+  //
+  // The working directory that the command will be executed in.
+  // Defaults to the directory set by the container image.
+  string workdir = 3;
+
+  // OPTIONAL
+  //
+  // Path inside the container to a file which will be piped
+  // to the process's stdin. Must be an absolute path.
+  string stdin = 6;
+
+  // OPTIONAL
+  //
+  // Path inside the container to a file where the process's
+  // stdout will be written to. Must be an absolute path.
+  string stdout = 4;
+
+  // OPTIONAL
+  //
+  // Path inside the container to a file where the process's
+  // stderr will be written to. Must be an absolute path.
+  string stderr = 5;
+
+  // OPTIONAL
+  //
+  // Enviromental variables to set within the container.
+  map<string,string> env = 8;
 }
 
 enum FileType {
@@ -155,54 +192,6 @@ message Output {
   FileType type = 5;
 }
 
-// Executor describes a command to be executed, and its environment.
-message Executor {
-
-  // REQUIRED
-  //
-  // Name of the container image, for example:
-  // ubuntu
-  // quay.io/aptible/ubuntu
-  // gcr.io/my-org/my-image
-  // etc...
-  string image = 1;
-
-  // REQUIRED
-  //
-  // A sequence of program arguments to execute, where the first argument
-  // is the program to execute (i.e. argv).
-  repeated string command = 2;
-
-  // OPTIONAL
-  //
-  // The working directory that the command will be executed in.
-  // Defaults to the directory set by the container image.
-  string workdir = 3;
-
-  // OPTIONAL
-  //
-  // Path inside the container to a file which will be piped
-  // to the executor's stdin. Must be an absolute path.
-  string stdin = 6;
-
-  // OPTIONAL
-  //
-  // Path inside the container to a file where the executor's
-  // stdout will be written to. Must be an absolute path.
-  string stdout = 4;
-
-  // OPTIONAL
-  //
-  // Path inside the container to a file where the executor's
-  // stderr will be written to. Must be an absolute path.
-  string stderr = 5;
-
-  // OPTIONAL
-  //
-  // Enviromental variables to set within the container.
-  map<string,string> env = 8;
-}
-
 // Resources describes the resources requested by a task.
 message Resources {
 
@@ -237,11 +226,6 @@ message Resources {
 // TaskLog describes logging information related to a Task.
 message TaskLog {
 
-  // REQUIRED
-  //
-  // Logs for each executor
-  repeated ExecutorLog logs = 1;
-
   // OPTIONAL
   //
   // Arbitrary logging metadata included by the implementation.
@@ -250,11 +234,16 @@ message TaskLog {
   // OPTIONAL
   //
   // When the task started, in RFC 3339 format.
+  //
+  // The task has started when it enters the INITIALIZING state.
   string start_time = 3;
 
   // OPTIONAL
   //
   // When the task ended, in RFC 3339 format.
+  //
+  // The task has ended when it enters the COMPLETE, EXECUTOR_ERROR,
+  // SYSTEM_ERROR, or CANCELED state.
   string end_time = 4;
 
   // REQUIRED
@@ -265,8 +254,7 @@ message TaskLog {
   
   // OPTIONAL
   //
-  // System logs are any logs the system decides are relevant,
-  // which are not tied directly to an Executor process.
+  // System logs are any logs the system decides are relevant.
   // Content is implementation specific: format, size, etc.
   //
   // System logs may be collected here to provide convenient access.
@@ -277,22 +265,6 @@ message TaskLog {
   //
   // System logs are only included in the FULL task view.
   repeated string system_logs = 6;
-}
-
-// OUTPUT ONLY
-//
-// ExecutorLog describes logging information related to an Executor.
-message ExecutorLog {
-
-  // OPTIONAL
-  //
-  // Time the executor started, in RFC 3339 format.
-  string start_time = 2;
-
-  // OPTIONAL
-  //
-  // Time the executor ended, in RFC 3339 format.
-  string end_time = 3;
 
   // OPTIONAL
   //
@@ -302,7 +274,7 @@ message ExecutorLog {
   // Implementations may chose different approaches: only the head, only the tail,
   // a URL reference only, etc.
   //
-  // In order to capture the full stdout users should set Executor.stdout
+  // In order to capture the full stdout users should set Task.stdout
   // to a container file path, and use Task.outputs to upload that file
   // to permanent storage.
   string stdout = 4;
@@ -315,7 +287,7 @@ message ExecutorLog {
   // Implementations may chose different approaches: only the head, only the tail,
   // a URL reference only, etc.
   //
-  // In order to capture the full stderr users should set Executor.stderr
+  // In order to capture the full stderr users should set Task.stderr
   // to a container file path, and use Task.outputs to upload that file
   // to permanent storage.
   string stderr = 5;
@@ -368,8 +340,7 @@ enum State {
   // For example, the worker may be turning on, downloading input files, etc.
   INITIALIZING = 2;
 
-  // The task is running. Input files are downloaded and the first Executor
-  // has been started.
+  // The task is running. Input files are downloaded and command is running.
   RUNNING = 3;
 
   // The task is paused.
@@ -377,17 +348,15 @@ enum State {
   // An implementation may have the ability to pause a task, but this is not required.
   PAUSED = 4;
 
-  // The task has completed running. Executors have exited without error
-  // and output files have been successfully uploaded.
+  // The task has completed running and output files have been successfully uploaded.
   COMPLETE = 5;
 
-  // The task encountered an error in one of the Executor processes. Generally,
-  // this means that an Executor exited with a non-zero exit code.
+  // The task failed to run the command.
+  // Usually this means the command exited with a non-zero exit code.
   EXECUTOR_ERROR = 6;
 
-  // The task was stopped due to a system error, but not from an Executor,
-  // for example an upload failed due to network issues, the worker's ran out
-  // of disk space, etc.
+  // The task was stopped due to a system error, for example an upload failed
+  // due to network issues, the worker's ran out of disk space, etc.
   SYSTEM_ERROR = 7;
 
   // The task was canceled by the user.
@@ -461,9 +430,9 @@ enum TaskView {
   MINIMAL = 0;
 
   // Task message will include all fields EXCEPT:
-  //   Task.ExecutorLog.stdout
-  //   Task.ExecutorLog.stderr
   //   Input.content
+  //   TaskLog.stdout
+  //   TaskLog.stderr
   //   TaskLog.system_logs
   BASIC = 1;
 


### PR DESCRIPTION
closes #59 

Note that start/end time are the task start/end time (including download/upload time) as opposed to the command start/end time (which would not include download/upload time). Fine grained timing support can be added on a per-implementation basis using metadata or system logs.