### PR TITLE
Proposal: add "additional_properties" to tesResources

### DIFF
--- a/openapi/task_execution.swagger.yaml
+++ b/openapi/task_execution.swagger.yaml
@@ -394,6 +394,11 @@ definitions:
         items:
           type: string
         description: Request that the task be run in these compute zones.
+      additional_properties:
+        type: object
+        additionalProperties:
+          type: string
+        description: Key/value pairs for additional resource properties (e.g. a specific VM SKU)
     description: Resources describes the resources requested by a task.
   tesServiceInfo:
     type: object


### PR DESCRIPTION
According to the WDL spec, "The runtime section defines key/value pairs for runtime information needed for this task":

https://github.com/openwdl/wdl/blob/master/versions/1.0/SPEC.md#runtime-section

This commit extends tesResources to support an arbitrary dictionary of additional properties, which ensures WDL parsers can pass-through their full list of runtime key/value pairs to a TES backend.  The canonical example of its use would be for WDL authors to be able to specify a specific cloud VM SKU in their WDL files.