### PR TITLE
OpenAPI 3

### DIFF
--- a/openapi/task_execution_service.openapi.yaml
+++ b/openapi/task_execution_service.openapi.yaml
@@ -1,0 +1,575 @@
+openapi: 3.0.1
+info:
+  title: Task Execution Service
+  version: 0.4.0
+servers:
+- url: /ga4gh/tes/v1
+paths:
+  /tasks:
+    get:
+      tags:
+      - TaskService
+      summary: |-
+        List tasks.
+        TaskView is requested as such: "v1/tasks?view=BASIC"
+      operationId: ListTasks
+      parameters:
+      - name: name_prefix
+        in: query
+        description: |-
+          OPTIONAL. Filter the list to include tasks where the name matches this prefix.
+          If unspecified, no task name filtering is done.
+        schema:
+          type: string
+      - name: page_size
+        in: query
+        description: |-
+          OPTIONAL. Number of tasks to return in one page.
+          Must be less than 2048. Defaults to 256.
+        schema:
+          type: integer
+          format: int64
+      - name: page_token
+        in: query
+        description: |-
+          OPTIONAL. Page token is used to retrieve the next page of results.
+          If unspecified, returns the first page of results.
+          See ListTasksResponse.next_page_token
+        schema:
+          type: string
+      - name: view
+        in: query
+        description: |-
+          OPTIONAL. Affects the fields included in the returned Task messages.
+          See TaskView below.
+
+           - MINIMAL: Task message will include ONLY the fields:
+            Task.Id
+            Task.State
+           - BASIC: Task message will include all fields EXCEPT:
+            Task.ExecutorLog.stdout
+            Task.ExecutorLog.stderr
+            Input.content
+            TaskLog.system_logs
+           - FULL: Task message includes all fields.
+        schema:
+          type: string
+          default: MINIMAL
+          enum:
+          - MINIMAL
+          - BASIC
+          - FULL
+      responses:
+        200:
+          description: ""
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/tesListTasksResponse'
+    post:
+      tags:
+      - TaskService
+      summary: Create a new task.
+      operationId: CreateTask
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/tesTask'
+        required: true
+      responses:
+        200:
+          description: ""
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/tesCreateTaskResponse'
+      x-codegen-request-body-name: body
+  /tasks/service-info:
+    get:
+      tags:
+      - TaskService
+      summary: "GetServiceInfo provides information about the service,\nsuch as storage\
+        \ details, resource availability, and \nother documentation."
+      operationId: GetServiceInfo
+      responses:
+        200:
+          description: ""
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/tesServiceInfo'
+  /tasks/{id}:
+    get:
+      tags:
+      - TaskService
+      summary: |-
+        Get a task.
+        TaskView is requested as such: "v1/tasks/{id}?view=FULL"
+      operationId: GetTask
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: view
+        in: query
+        description: |-
+          OPTIONAL. Affects the fields included in the returned Task messages.
+          See TaskView below.
+
+           - MINIMAL: Task message will include ONLY the fields:
+            Task.Id
+            Task.State
+           - BASIC: Task message will include all fields EXCEPT:
+            Task.ExecutorLog.stdout
+            Task.ExecutorLog.stderr
+            Input.content
+            TaskLog.system_logs
+           - FULL: Task message includes all fields.
+        schema:
+          type: string
+          default: MINIMAL
+          enum:
+          - MINIMAL
+          - BASIC
+          - FULL
+      responses:
+        200:
+          description: ""
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/tesTask'
+  /tasks/{id}:cancel:
+    post:
+      tags:
+      - TaskService
+      summary: Cancel a task.
+      operationId: CancelTask
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        200:
+          description: ""
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/tesCancelTaskResponse'
+components:
+  schemas:
+    tesCancelTaskResponse:
+      type: object
+      description: CancelTaskResponse describes a response from the CancelTask endpoint.
+    tesCreateTaskResponse:
+      required:
+      - id
+      type: object
+      properties:
+        id:
+          type: string
+          description: Task identifier assigned by the server.
+      description: CreateTaskResponse describes a response from the CreateTask endpoint.
+    tesExecutor:
+      required:
+      - command
+      - image
+      type: object
+      properties:
+        image:
+          type: string
+          description: |-
+            Name of the container image, for example:
+            ubuntu
+            quay.io/aptible/ubuntu
+            gcr.io/my-org/my-image
+            etc...
+        command:
+          type: array
+          description: |-
+            A sequence of program arguments to execute, where the first argument
+            is the program to execute (i.e. argv).
+          items:
+            type: string
+        workdir:
+          type: string
+          description: |-
+            The working directory that the command will be executed in.
+            Defaults to the directory set by the container image.
+        stdin:
+          type: string
+          description: |-
+            Path inside the container to a file which will be piped
+            to the executor's stdin. Must be an absolute path.
+        stdout:
+          type: string
+          description: |-
+            Path inside the container to a file where the executor's
+            stdout will be written to. Must be an absolute path.
+        stderr:
+          type: string
+          description: |-
+            Path inside the container to a file where the executor's
+            stderr will be written to. Must be an absolute path.
+        env:
+          type: object
+          additionalProperties:
+            type: string
+          description: Enviromental variables to set within the container.
+      description: Executor describes a command to be executed, and its environment.
+    tesExecutorLog:
+      required:
+      - exit_code
+      type: object
+      properties:
+        start_time:
+          type: string
+          description: Time the executor started, in RFC 3339 format.
+        end_time:
+          type: string
+          description: Time the executor ended, in RFC 3339 format.
+        stdout:
+          type: string
+          description: |-
+            Stdout content.
+
+            This is meant for convenience. No guarantees are made about the content.
+            Implementations may chose different approaches: only the head, only the tail,
+            a URL reference only, etc.
+
+            In order to capture the full stdout users should set Executor.stdout
+            to a container file path, and use Task.outputs to upload that file
+            to permanent storage.
+        stderr:
+          type: string
+          description: |-
+            Stderr content.
+
+            This is meant for convenience. No guarantees are made about the content.
+            Implementations may chose different approaches: only the head, only the tail,
+            a URL reference only, etc.
+
+            In order to capture the full stderr users should set Executor.stderr
+            to a container file path, and use Task.outputs to upload that file
+            to permanent storage.
+        exit_code:
+          type: integer
+          description: Exit code.
+          format: int32
+      description: ExecutorLog describes logging information related to an Executor.
+    tesFileType:
+      type: string
+      default: FILE
+      enum:
+      - FILE
+      - DIRECTORY
+    tesInput:
+      required:
+      - path
+      - type
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        url:
+          type: string
+          description: |-
+            REQUIRED, unless "content" is set.
+
+            URL in long term storage, for example:
+            s3://my-object-store/file1
+            gs://my-bucket/file2
+            file:///path/to/my/file
+            /path/to/my/file
+            etc...
+        path:
+          type: string
+          description: |-
+            Path of the file inside the container.
+            Must be an absolute path.
+        type:
+          $ref: '#/components/schemas/tesFileType'
+        content:
+          type: string
+          description: "File content literal. \nImplementations should support a minimum\
+            \ of 128 KiB in this field and may define its own maximum.\nUTF-8 encoded\n\
+            \nIf content is not empty, \"url\" must be ignored."
+      description: Input describes Task input files.
+    tesListTasksResponse:
+      required:
+      - tasks
+      type: object
+      properties:
+        tasks:
+          type: array
+          description: List of tasks.
+          items:
+            $ref: '#/components/schemas/tesTask'
+        next_page_token:
+          type: string
+          description: |-
+            Token used to return the next page of results.
+            See TaskListRequest.next_page_token
+      description: ListTasksResponse describes a response from the ListTasks endpoint.
+    tesOutput:
+      required:
+      - path
+      - type
+      - url
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        url:
+          type: string
+          description: |-
+            URL in long term storage, for example:
+            s3://my-object-store/file1
+            gs://my-bucket/file2
+            file:///path/to/my/file
+            /path/to/my/file
+            etc...
+        path:
+          type: string
+          description: |-
+            Path of the file inside the container.
+            Must be an absolute path.
+        type:
+          $ref: '#/components/schemas/tesFileType'
+      description: Output describes Task output files.
+    tesOutputFileLog:
+      required:
+      - path
+      - size_bytes
+      - url
+      type: object
+      properties:
+        url:
+          type: string
+          description: URL of the file in storage, e.g. s3://bucket/file.txt
+        path:
+          type: string
+          description: Path of the file inside the container. Must be an absolute
+            path.
+        size_bytes:
+          type: string
+          description: Size of the file in bytes.
+          format: int64
+      description: |-
+        OutputFileLog describes a single output file. This describes
+        file details after the task has completed successfully,
+        for logging purposes.
+    tesResources:
+      type: object
+      properties:
+        cpu_cores:
+          type: integer
+          description: Requested number of CPUs
+          format: int64
+        preemptible:
+          type: boolean
+          description: Is the task allowed to run on preemptible compute instances
+            (e.g. AWS Spot)?
+          format: boolean
+        ram_gb:
+          type: number
+          description: Requested RAM required in gigabytes (GB)
+          format: double
+        disk_gb:
+          type: number
+          description: Requested disk size in gigabytes (GB)
+          format: double
+        zones:
+          type: array
+          description: Request that the task be run in these compute zones.
+          items:
+            type: string
+      description: Resources describes the resources requested by a task.
+    tesServiceInfo:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Returns the name of the service, e.g. "ohsu-compbio-funnel".
+        doc:
+          type: string
+          description: Returns a documentation string, e.g. "Hey, we're OHSU Comp.
+            Bio!".
+        storage:
+          type: array
+          description: "Lists some, but not necessarily all, storage locations supported\
+            \ by the service.\n\nMust be in a valid URL format.\ne.g. \nfile:///path/to/local/funnel-storage\n\
+            s3://ohsu-compbio-funnel/storage\netc."
+          items:
+            type: string
+      description: |-
+        ServiceInfo describes information about the service,
+        such as storage details, resource availability,
+        and other documentation.
+    tesState:
+      type: string
+      description: |-
+        Task states.
+
+         - UNKNOWN: The state of the task is unknown.
+
+        This provides a safe default for messages where this field is missing,
+        for example, so that a missing field does not accidentally imply that
+        the state is QUEUED.
+         - QUEUED: The task is queued.
+         - INITIALIZING: The task has been assigned to a worker and is currently preparing to run.
+        For example, the worker may be turning on, downloading input files, etc.
+         - RUNNING: The task is running. Input files are downloaded and the first Executor
+        has been started.
+         - PAUSED: The task is paused.
+
+        An implementation may have the ability to pause a task, but this is not required.
+         - COMPLETE: The task has completed running. Executors have exited without error
+        and output files have been successfully uploaded.
+         - EXECUTOR_ERROR: The task encountered an error in one of the Executor processes. Generally,
+        this means that an Executor exited with a non-zero exit code.
+         - SYSTEM_ERROR: The task was stopped due to a system error, but not from an Executor,
+        for example an upload failed due to network issues, the worker's ran out
+        of disk space, etc.
+         - CANCELED: The task was canceled by the user.
+      default: UNKNOWN
+      enum:
+      - UNKNOWN
+      - QUEUED
+      - INITIALIZING
+      - RUNNING
+      - PAUSED
+      - COMPLETE
+      - EXECUTOR_ERROR
+      - SYSTEM_ERROR
+      - CANCELED
+    tesTask:
+      required:
+      - executors
+      type: object
+      properties:
+        id:
+          type: string
+          description: Task identifier assigned by the server.
+          readOnly: true
+        state:
+          $ref: '#/components/schemas/tesState'
+        name:
+          type: string
+        description:
+          type: string
+        inputs:
+          type: array
+          description: |-
+            Input files.
+            Inputs will be downloaded and mounted into the executor container.
+          items:
+            $ref: '#/components/schemas/tesInput'
+        outputs:
+          type: array
+          description: |-
+            Output files.
+            Outputs will be uploaded from the executor container to long-term storage.
+          items:
+            $ref: '#/components/schemas/tesOutput'
+        resources:
+          $ref: '#/components/schemas/tesResources'
+        executors:
+          type: array
+          description: |-
+            A list of executors to be run, sequentially. Execution stops
+            on the first error.
+          items:
+            $ref: '#/components/schemas/tesExecutor'
+        volumes:
+          type: array
+          description: |-
+            Volumes are directories which may be used to share data between
+            Executors. Volumes are initialized as empty directories by the
+            system when the task starts and are mounted at the same path
+            in each Executor.
+
+            For example, given a volume defined at "/vol/A",
+            executor 1 may write a file to "/vol/A/exec1.out.txt", then
+            executor 2 may read from that file.
+
+            (Essentially, this translates to a `docker run -v` flag where
+            the container path is the same for each executor).
+          items:
+            type: string
+        tags:
+          type: object
+          additionalProperties:
+            type: string
+          description: A key-value map of arbitrary tags.
+        logs:
+          type: array
+          description: |-
+            Task logging information.
+            Normally, this will contain only one entry, but in the case where
+            a task fails and is retried, an entry will be appended to this list.
+          readOnly: true
+          items:
+            $ref: '#/components/schemas/tesTaskLog'
+        creation_time:
+          type: string
+          description: |-
+            Date + time the task was created, in RFC 3339 format.
+            This is set by the system, not the client.
+          readOnly: true
+      description: Task describes an instance of a task.
+    tesTaskLog:
+      required:
+      - logs
+      - outputs
+      type: object
+      properties:
+        logs:
+          type: array
+          description: Logs for each executor
+          items:
+            $ref: '#/components/schemas/tesExecutorLog'
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
+          description: Arbitrary logging metadata included by the implementation.
+        start_time:
+          type: string
+          description: When the task started, in RFC 3339 format.
+        end_time:
+          type: string
+          description: When the task ended, in RFC 3339 format.
+        outputs:
+          type: array
+          description: |-
+            Information about all output files. Directory outputs are
+            flattened into separate items.
+          items:
+            $ref: '#/components/schemas/tesOutputFileLog'
+        system_logs:
+          type: array
+          description: |-
+            System logs are any logs the system decides are relevant,
+            which are not tied directly to an Executor process.
+            Content is implementation specific: format, size, etc.
+
+            System logs may be collected here to provide convenient access.
+
+            For example, the system may include the name of the host
+            where the task is executing, an error message that caused
+            a SYSTEM_ERROR state (e.g. disk is full), etc.
+
+            System logs are only included in the FULL task view.
+          items:
+            type: string
+      description: TaskLog describes logging information related to a Task.

--- a/openapi/task_execution_service.openapi.yaml
+++ b/openapi/task_execution_service.openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.1
 info:
   title: Task Execution Service
-  version: 0.4.0
+  version: 0.5.0
 servers:
 - url: /ga4gh/tes/v1
 paths:

--- a/openapi/task_execution_service.openapi.yaml
+++ b/openapi/task_execution_service.openapi.yaml
@@ -5,6 +5,20 @@ info:
 servers:
 - url: /ga4gh/tes/v1
 paths:
+  /service-info:
+    get:
+      tags:
+      - TaskService
+      summary: "GetServiceInfo provides information about the service,\nsuch as storage\
+         \ details, resource availability, and \nother documentation."
+      operationId: GetServiceInfo
+      responses:
+        200:
+          description: ""
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/tesServiceInfo'
   /tasks:
     get:
       tags:
@@ -85,20 +99,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/tesCreateTaskResponse'
       x-codegen-request-body-name: body
-  /tasks/service-info:
-    get:
-      tags:
-      - TaskService
-      summary: "GetServiceInfo provides information about the service,\nsuch as storage\
-        \ details, resource availability, and \nother documentation."
-      operationId: GetServiceInfo
-      responses:
-        200:
-          description: ""
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/tesServiceInfo'
   /tasks/{id}:
     get:
       tags:
@@ -395,26 +395,17 @@ components:
             type: string
       description: Resources describes the resources requested by a task.
     tesServiceInfo:
-      type: object
-      properties:
-        name:
-          type: string
-          description: Returns the name of the service, e.g. "ohsu-compbio-funnel".
-        doc:
-          type: string
-          description: Returns a documentation string, e.g. "Hey, we're OHSU Comp.
-            Bio!".
-        storage:
-          type: array
-          description: "Lists some, but not necessarily all, storage locations supported\
-            \ by the service.\n\nMust be in a valid URL format.\ne.g. \nfile:///path/to/local/funnel-storage\n\
-            s3://ohsu-compbio-funnel/storage\netc."
-          items:
-            type: string
-      description: |-
-        ServiceInfo describes information about the service,
-        such as storage details, resource availability,
-        and other documentation.
+      allOf:
+      - $ref: 'https://raw.githubusercontent.com/ga4gh-discovery/ga4gh-service-info/v1.0.0/service-info.yaml#/components/schemas/Service'
+      - type: object
+        properties:
+          storage:
+            type: array
+            description: "Lists some, but not necessarily all, storage locations supported\
+              \ by the service.\n\nMust be in a valid URL format.\ne.g. \nfile:///path/to/local/funnel-storage\n\
+              s3://ohsu-compbio-funnel/storage\netc."
+            items:
+              type: string
     tesState:
       type: string
       description: |-


### PR DESCRIPTION
The result of conversion from OpenAPI 2 to 3 using https://converter.swagger.io/ without any changes
Checks so far: 
- https://validator.swagger.io/validator/?url=https%3A%2F%2Fraw.githubusercontent.com%2Faniewielska%2Ftask-execution-schemas%2Fopenapi3%2Fopenapi%2Ftask_execution_service.openapi.yaml
It seems to pass validation (unlike WES).
- I ran the new spec through OpenAPI codegen for Java and got roughly the same wire format (minus ServiceInfo which now has lots of new fields). Also required seems now to be acknowledged by the generator for Java 
TODOs:
- compare with WES and try to align
I noticed that WES additionally has:
-- Error code responses listed (400, 404 etc) - not sure, if we want to add it at that stage. Breaking change.
-- Error response model - not sure, if we want to add it at that stage. Breaking change
-- URL defined as composite of host, path This we can do for TES.
-- Executive Summary - this is what we need for docs generation
- ~~externalise ServiceInfo~~ - DONE. I added additional storage and moved '/service-info' outside of '/tasks'. That is breaking change as well, but seems required.