### PR TITLE
New docs build system

### DIFF
--- a/.spec-docs.json
+++ b/.spec-docs.json
@@ -1,0 +1,4 @@
+{
+  "apiSpecPath": "openapi/task_execution_service.openapi.yaml",
+  "redocTheme": "ga4gh"
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+jobs:
+  include:
+  - stage: build_docs
+    language: node_js
+    node_js:
+    - "12"
+    before_script:
+    - npm install -g @redocly/openapi-cli \
+      && npm install -g redoc-cli
+    - npm install -g @ga4gh/gh-openapi-docs
+    script:
+    - gh-openapi-docs
+    deploy:
+      provider: pages
+      skip-cleanup: true
+      keep_history: true
+      github-token: $GITHUB_TOKEN
+      on:
+        all_branches: true

--- a/openapi/task_execution_service.openapi.yaml
+++ b/openapi/task_execution_service.openapi.yaml
@@ -2,6 +2,9 @@ openapi: 3.0.1
 info:
   title: Task Execution Service
   version: 0.5.0
+  description: >
+    ## Executive Summary
+    The Task Execution Service (TES) API is an effort to define a standardized schema and API for describing batch execution tasks. A task defines a set of input files, a set of (Docker) containers and commands to run, a set of output files, and some other logging and metadata.
 servers:
 - url: /ga4gh/tes/v1
 paths:

--- a/openapi/task_execution_service.openapi.yaml
+++ b/openapi/task_execution_service.openapi.yaml
@@ -4,6 +4,7 @@ info:
   version: 0.5.0
   description: >
     ## Executive Summary
+
     The Task Execution Service (TES) API is an effort to define a standardized schema and API for describing batch execution tasks. A task defines a set of input files, a set of (Docker) containers and commands to run, a set of output files, and some other logging and metadata.
 servers:
 - url: /ga4gh/tes/v1
@@ -12,8 +13,8 @@ paths:
     get:
       tags:
       - TaskService
-      summary: "GetServiceInfo provides information about the service,\nsuch as storage\
-         \ details, resource availability, and \nother documentation."
+      summary: "GetServiceInfo"
+      description:   "Provides information about the service, such as storage details, resource availability, and other documentation."
       operationId: GetServiceInfo
       responses:
         200:


### PR DESCRIPTION
This is a preview of how to add ReDoc to TES.
(1) It builds on top of OpenAPI3, so it contains changes from #132 and builds on top of them (it would be good to accept the Open API 3 spec first and later add docs).
(2) Also the build system assumes the existence of the `gh-pages` branch, so that needs to be created beforehand.
(3) The actual needed changes are:
- .spec-docs.json
- .travis.yml
 
(4) I also changed the spec a bit to improve the layout of generated docs, but still the result looks differently from the WES one. I am not sure, if the ga4gh theme worked or if it is expected to work for a fork.
 
The result is not any pretty yet and can be seen here: https://aniewielska.github.io/task-execution-schemas/preview/new-docs-build/docs/