### PR TITLE
New docs build system

### DIFF
--- a/.spec-docs.json
+++ b/.spec-docs.json
@@ -1,0 +1,4 @@
+{
+  "apiSpecPath": "openapi/task_execution_service.openapi.yaml",
+  "redocTheme": "ga4gh"
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jobs:
     before_script:
     - npm install -g @redocly/openapi-cli \
       && npm install -g redoc-cli
-    - npm install -g @ga4gh/gh-openapi-docs
+    - npm install -g gh-openapi-docs
     script:
     - gh-openapi-docs
     deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+jobs:
+  include:
+  - stage: build_docs
+    language: node_js
+    node_js:
+    - "12"
+    before_script:
+    - npm install -g @redocly/openapi-cli \
+      && npm install -g redoc-cli
+    - npm install -g @ga4gh/gh-openapi-docs
+    script:
+    - gh-openapi-docs
+    deploy:
+      provider: pages
+      skip-cleanup: true
+      keep_history: true
+      github-token: $GITHUB_TOKEN
+      on:
+        all_branches: true

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Task Execution Service (TES) API
 ======================================
 <sup>`master` branch status: </sup>[![Build Status](https://travis-ci.org/ga4gh/task-execution-schemas.svg?branch=master)](https://travis-ci.org/ga4gh/task-execution-schemas?branch=master)
-<a href="https://raw.githubusercontent.com/ga4gh/task-execution-schemas/master/openapi/task_execution.swagger.yaml"><img src="http://online.swagger.io/validator?url=https://raw.githubusercontent.com/ga4gh/task-execution-schemas/master/openapi/task_execution.swagger.yaml" alt="Swagger Validator" height="20em" width="72em"></A>
+<a href="https://raw.githubusercontent.com/ga4gh/task-execution-schemas/master/openapi/task_execution_service.openapi.yaml"><img src="http://online.swagger.io/validator?url=https://raw.githubusercontent.com/ga4gh/task-execution-schemas/master/openapi/task_execution_service.openapi.yaml" alt="Open API Validator" height="20em" width="72em"></A>
 
 The [Global Alliance for Genomics and Health](http://genomicsandhealth.org/) is an international coalition, formed to enable the sharing of genomic and clinical data.
 
@@ -23,22 +23,30 @@ and API for describing batch execution tasks. A task defines a set of input file
 a set of (Docker) containers and commands to run, a set of output files,
 and some other logging and metadata.
 
-TES Complaiant Implementations
-==============================
+API Definition
+--------------
+
+See the human-readable [Reference Documentation](https://ga4gh.github.io/task-execution-schemas/docs/)
+and the [OpenAPI YAML description](openapi/task_execution_service.openapi.yaml). You can also explore the specification in the [Swagger Editor](https://editor.swagger.io/?url=https://ga4gh.github.io/task-execution-schemas/openapi.yaml).
+
+> All documentation and pages hosted at 'ga4gh.github.io/task-execution-schemas' reflect the latest API release from the `master` branch. To monitor the latest development work, add 'preview/\<branch\>' to the URLs above (e.g., 'ga4gh.github.io/task-execution-schemas/preview/\<branch\>/docs').
+
+TES Compliant Implementations
+------------------------------
 - [Funnel](https://ohsu-comp-bio.github.io/funnel/)
 - [TESK](https://github.com/EMBL-EBI-TSI/TESK)
 - [tes-azure](https://github.com/microsoft/tes-azure)
 
 
 TES Service Examples
-==============================
+------------------------------
 
-The schema and APIs is defined [here](./openapi/task_execution.swagger.yaml) in [Open Api Specification 2.0](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md) (e.g [Swagger](https://swagger.io/specification/v2/)). Clients may use JSON and REST to communicate
+The schema and APIs is defined [here](openapi/task_execution_service.openapi.yaml) in [Open Api Specification 3.0.1](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md). Clients may use JSON and REST to communicate
 with a service implementing the TES API.
 
 
-Create a task
----------------------------------
+### Create a task
+
 
 Here's an example of a complete task message, defining a task which calculates
 an MD5 checksum on an input file and uploads the output:
@@ -117,8 +125,8 @@ POST /v1/tasks
 The return value is a task ID.
 
 
-Get a task
---------------------------------
+### Get a task
+
 
 To get a task by ID:
 
@@ -150,8 +158,8 @@ GET /v1/tasks/task-1234?view=FULL
   "logs": [{ "stdout": "stdout content..." }], etc... }
 ```
 
-List tasks
-------------------------------------
+### List tasks
+
 
 To list tasks:
 
@@ -167,8 +175,8 @@ GET /v1/tasks?view=BASIC
 ```
 
 
-Cancel a task
--------------------------------------
+### Cancel a task
+
 
 To cancel a task, send an HTTP POST to the cancel endpoint:
 ```HTTP

--- a/openapi/task_execution_service.openapi.yaml
+++ b/openapi/task_execution_service.openapi.yaml
@@ -2,6 +2,9 @@ openapi: 3.0.1
 info:
   title: Task Execution Service
   version: 0.5.0
+  description: >
+    ## Executive Summary
+    The Task Execution Service (TES) API is an effort to define a standardized schema and API for describing batch execution tasks. A task defines a set of input files, a set of (Docker) containers and commands to run, a set of output files, and some other logging and metadata.
 servers:
 - url: /ga4gh/tes/v1
 paths:

--- a/openapi/task_execution_service.openapi.yaml
+++ b/openapi/task_execution_service.openapi.yaml
@@ -4,6 +4,7 @@ info:
   version: 0.5.0
   description: >
     ## Executive Summary
+
     The Task Execution Service (TES) API is an effort to define a standardized schema and API for describing batch execution tasks. A task defines a set of input files, a set of (Docker) containers and commands to run, a set of output files, and some other logging and metadata.
 servers:
 - url: /ga4gh/tes/v1
@@ -12,8 +13,8 @@ paths:
     get:
       tags:
       - TaskService
-      summary: "GetServiceInfo provides information about the service,\nsuch as storage\
-         \ details, resource availability, and \nother documentation."
+      summary: "GetServiceInfo"
+      description:   "Provides information about the service, such as storage details, resource availability, and other documentation."
       operationId: GetServiceInfo
       responses:
         200:

--- a/openapi/task_execution_service.openapi.yaml
+++ b/openapi/task_execution_service.openapi.yaml
@@ -2,6 +2,8 @@ openapi: 3.0.1
 info:
   title: Task Execution Service
   version: 0.5.0
+  x-logo:
+    url: 'https://www.ga4gh.org/wp-content/themes/ga4gh-theme/gfx/GA-logo-horizontal-tag-RGB.svg'
   description: >
     ## Executive Summary
 
@@ -13,7 +15,7 @@ paths:
     get:
       tags:
       - TaskService
-      summary: "GetServiceInfo"
+      summary: GetServiceInfo
       description:   "Provides information about the service, such as storage details, resource availability, and other documentation."
       operationId: GetServiceInfo
       responses:
@@ -27,7 +29,8 @@ paths:
     get:
       tags:
       - TaskService
-      summary: |-
+      summary: ListTasks
+      description: |-
         List tasks.
         TaskView is requested as such: "v1/tasks?view=BASIC"
       operationId: ListTasks
@@ -87,7 +90,8 @@ paths:
     post:
       tags:
       - TaskService
-      summary: Create a new task.
+      summary: CreateTask
+      description: Create a new task.
       operationId: CreateTask
       requestBody:
         content:
@@ -107,7 +111,8 @@ paths:
     get:
       tags:
       - TaskService
-      summary: |-
+      summary: GetTask
+      description: |-
         Get a task.
         TaskView is requested as such: "v1/tasks/{id}?view=FULL"
       operationId: GetTask
@@ -150,7 +155,8 @@ paths:
     post:
       tags:
       - TaskService
-      summary: Cancel a task.
+      summary: CancelTask
+      description: Cancel a task.
       operationId: CancelTask
       parameters:
       - name: id


### PR DESCRIPTION
This PR brings machinery of building ReDoc to TES.
I created an empty orphaned `gh-pages` branch and set up GITHUB_TOKEN in Travis.
As a result the docs are being generated, ~~but still the result is visually different than the one for WES.~~ and finally they resemble the ones for WES! (The package version mentioned in the migration instructions was wrong).
You can see the results here: http://ga4gh.github.io/task-execution-schemas/preview/new-docs-build/docs/
The missing parts - reorganising parts of description/titles and adding more executive summary.
Also it would be nice to add links to the docs to READ.me
