### PR TITLE
Introduce fixed service info type

### DIFF
--- a/openapi/task_execution_service.openapi.yaml
+++ b/openapi/task_execution_service.openapi.yaml
@@ -518,6 +518,17 @@ components:
             type: string
           example: us-west-1
       description: Resources describes the resources requested by a task.
+    tesServiceType:
+      allOf:
+      - $ref: 'https://raw.githubusercontent.com/ga4gh-discovery/ga4gh-service-info/v1.0.0/service-info.yaml#/components/schemas/ServiceType'
+      - type: object
+        required:
+        - artifact
+        properties:
+          artifact:
+            type: string
+            enum: [tes]
+            example: tes
     tesServiceInfo:
       allOf:
       - $ref: 'https://raw.githubusercontent.com/ga4gh-discovery/ga4gh-service-info/v1.0.0/service-info.yaml#/components/schemas/Service'
@@ -533,6 +544,8 @@ components:
             example:
                - file:///path/to/local/funnel-storage
                - s3://ohsu-compbio-funnel/storage
+          type:
+            $ref: '#/components/schemas/tesServiceType'
     tesState:
       type: string
       readOnly: True


### PR DESCRIPTION
This PR sets the value of ServiceType artifact to `tes`. Looks decently in ReDoc and in OpenAPI generator, but I am not sure, if this is the best possible option in OpenAPI.
Work inspired by [htsget](https://github.com/samtools/hts-specs/pull/493/files), as there seems to be no good examples in Cloud Workstream.