### PR TITLE
Deduplicate view param

### DIFF
--- a/openapi/task_execution_service.openapi.yaml
+++ b/openapi/task_execution_service.openapi.yaml
@@ -199,17 +199,17 @@ components:
       description: |-
         OPTIONAL. Affects the fields included in the returned Task messages.
 
-       `MINIMAL`: Task message will include ONLY the fields:
+        `MINIMAL`: Task message will include ONLY the fields:
         - `tesTask.Id`
         - `tesTask.State`
 
-       `BASIC`: Task message will include all fields EXCEPT:
+        `BASIC`: Task message will include all fields EXCEPT:
         - `tesTask.ExecutorLog.stdout`
         - `tesTask.ExecutorLog.stderr`
         - `tesInput.content`
         - `tesTaskLog.system_logs`
 
-       `FULL`: Task message includes all fields.
+        `FULL`: Task message includes all fields.
       schema:
         type: string
         default: MINIMAL

--- a/openapi/task_execution_service.openapi.yaml
+++ b/openapi/task_execution_service.openapi.yaml
@@ -116,30 +116,8 @@ paths:
           in the `next_page_token` field of the last returned result of ListTasks
         schema:
           type: string
-      - name: view
-        in: query
-        description: |-
-          OPTIONAL. Affects the fields included in the returned Task messages.
-          See TaskView below.
+      - $ref: '#/components/parameters/view'
 
-           `MINIMAL`: Task message will include ONLY the fields:
-             - `tesTask.Id`
-             - `tesTask.State`
-
-           `BASIC`: Task message will include all fields EXCEPT:
-             - `tesTask.ExecutorLog.stdout`
-             - `tesTask.ExecutorLog.stderr`
-             - `tesInput.content`
-             - `tesTaskLog.system_logs`
-
-           `FULL`: Task message includes all fields.
-        schema:
-          type: string
-          default: MINIMAL
-          enum:
-          - MINIMAL
-          - BASIC
-          - FULL
       responses:
         200:
           description: ""
@@ -184,28 +162,7 @@ paths:
         description: ID of task to retrieve.
         schema:
           type: string
-      - name: view
-        in: query
-        description: |-
-          OPTIONAL. Affects the fields included in the returned Task messages.
-          See TaskView below.
-
-           - `MINIMAL`: Task message will include ONLY the fields:
-            - Task.Id
-            - Task.State
-           - `BASIC`: Task message will include all fields EXCEPT:
-            - `Task.ExecutorLog.stdout`
-            - `Task.ExecutorLog.stderr`
-            - `Input.content`
-            - `TaskLog.system_logs`
-           - `FULL`: Task message includes all fields.
-        schema:
-          type: string
-          default: MINIMAL
-          enum:
-          - MINIMAL
-          - BASIC
-          - FULL
+      - $ref: '#/components/parameters/view'
       responses:
         200:
           description: ""
@@ -235,6 +192,32 @@ paths:
               schema:
                 $ref: '#/components/schemas/tesCancelTaskResponse'
 components:
+  parameters:
+    view:
+      name: view
+      in: query
+      description: |-
+        OPTIONAL. Affects the fields included in the returned Task messages.
+
+       `MINIMAL`: Task message will include ONLY the fields:
+        - `tesTask.Id`
+        - `tesTask.State`
+
+       `BASIC`: Task message will include all fields EXCEPT:
+        - `tesTask.ExecutorLog.stdout`
+        - `tesTask.ExecutorLog.stderr`
+        - `tesInput.content`
+        - `tesTaskLog.system_logs`
+
+       `FULL`: Task message includes all fields.
+      schema:
+        type: string
+        default: MINIMAL
+        enum:
+        - MINIMAL
+        - BASIC
+        - FULL
+
   schemas:
     tesCancelTaskResponse:
       type: object


### PR DESCRIPTION
This PR externalises the `view` parameter of list and get task. ~There is some problem generating GH pages after this change in my fork (but the files got generated in gh-pages), so let's see, if the problem is universal~ (it worked).