### PR TITLE
Add security related topics to spec

### DIFF
--- a/openapi/task_execution_service.openapi.yaml
+++ b/openapi/task_execution_service.openapi.yaml
@@ -40,7 +40,25 @@ info:
 
     The TES API specification is written in OpenAPI and embodies a RESTful service
     philosophy. It uses JSON in requests and responses and standard
-    HTTP/HTTPS for information transport.
+    HTTP/HTTPS for information transport. HTTPS should be used rather than plain HTTP
+    except for testing or internal-only purposes.
+
+    ### Authentication and Authorization
+
+    Is is envisaged that most TES API instances will require users to authenticate to use the endpoints.
+    However, the decision if authentication is required should be taken by TES API implementers.
+
+
+    If authentication is required, we recommend that TES implementations use an OAuth2  bearer token, although they can choose other mechanisms if appropriate.
+
+
+    Checking that a user is authorized to submit TES requests is a responsibility of TES implementations.
+
+    ### CORS
+
+    If TES API implementation is to be used by another website or domain it must implement Cross Origin Resource Sharing (CORS).
+    Please refer to https://w3id.org/ga4gh/product-approval-support/cors for more information about GA4GH’s recommendations and how to implement CORS.
+
 
 servers:
 - url: /ga4gh/tes/v1


### PR DESCRIPTION
I added HTTP/HTTPS, authentication and CORS related topics to descriptions in the specification. 
The text about CORS (almost) follows GA4GH recommendations and authentication tries to follow WES pattern.
We might revise later to impose security schemes directly in OpenAPI, but it wold be good to have GA4GH or at least Cloud WS common practices first.