### PR TITLE
Proposal: add "backend_parameters" to tesResources

### DIFF
--- a/openapi/task_execution_service.openapi.yaml
+++ b/openapi/task_execution_service.openapi.yaml
@@ -534,7 +534,7 @@ components:
                 ServiceInfo shall return a list of keys that a backend supports.
                 Keys are case insensitive.
                 Callers shall pass all runtime or hardware requirement key/values
-                that are not mapped to existing tesResources properties to backend_parameters 
+                that are not mapped to existing tesResources properties to backend_parameters.
                 Backends shall log system warnings if a key is passed that is unsupported.
                 Backends shall not store or return unsupported keys if included in a task.
                 Backends should attempt to run a task even if key/values are unsupported.

--- a/openapi/task_execution_service.openapi.yaml
+++ b/openapi/task_execution_service.openapi.yaml
@@ -530,7 +530,12 @@ components:
             additionalProperties:
                 type: string
             description: |-
-                Key/value pairs for additional resource properties (e.g. a specific VM SKU).  Example:
+                Key/value pairs for additional resource properties.
+                ServiceInfo shall return a list of keys that a backend supports.
+                Keys are case insensitive.
+                Backends shall log warnings if a key is passed that is unsupported.
+                Backends shall not store or return unsupported keys if included in a task. 
+                Example:
                 ```
                 {
                   "additional_properties" : {

--- a/openapi/task_execution_service.openapi.yaml
+++ b/openapi/task_execution_service.openapi.yaml
@@ -533,7 +533,7 @@ components:
                 Key/value pairs for backend configuration.
                 ServiceInfo shall return a list of keys that a backend supports.
                 Keys are case insensitive.
-                Callers shall pass all runtime or hardware requirement key/values
+                It is expected that clients pass all runtime or hardware requirement key/values
                 that are not mapped to existing tesResources properties to backend_parameters.
                 Backends shall log system warnings if a key is passed that is unsupported.
                 Backends shall not store or return unsupported keys if included in a task.

--- a/openapi/task_execution_service.openapi.yaml
+++ b/openapi/task_execution_service.openapi.yaml
@@ -525,6 +525,21 @@ components:
           items:
             type: string
           example: us-west-1
+        additional_properties:
+            type: object
+            additionalProperties:
+                type: string
+            description: |-
+                Key/value pairs for additional resource properties (e.g. a specific VM SKU).  Example:
+                ```
+                {
+                  "additional_properties" : {
+                    "VmSize" : "Standard_D64_v3"
+                  }
+                }
+                ```
+            example:
+                "VmSize" : "Standard_D64_v3"
       description: Resources describes the resources requested by a task.
     tesServiceType:
       allOf:

--- a/openapi/task_execution_service.openapi.yaml
+++ b/openapi/task_execution_service.openapi.yaml
@@ -537,7 +537,9 @@ components:
                 that are not mapped to existing tesResources properties to backend_parameters.
                 Backends shall log system warnings if a key is passed that is unsupported.
                 Backends shall not store or return unsupported keys if included in a task.
-                Backends should attempt to run a task even if key/values are unsupported.
+                If backend_parameters_strict equals true,
+                backends should fail the task if any key/values are unsupported, otherwise,
+                backends should attempt to run the task
                 Intended uses include VM size selection, coprocessor configuration, etc.
                 Example:
                 ```
@@ -549,6 +551,14 @@ components:
                 ```
             example:
                 "VmSize" : "Standard_D64_v3"
+        backend_parameters_strict:
+            type: boolean
+            description: |-
+                If set to true, backends should fail the task if any backend_parameters 
+                key/values are unsupported, otherwise, backends should attempt to run the task
+            format: boolean
+            default: false
+            example: false
       description: Resources describes the resources requested by a task.
     tesServiceType:
       allOf:

--- a/openapi/task_execution_service.openapi.yaml
+++ b/openapi/task_execution_service.openapi.yaml
@@ -533,6 +533,8 @@ components:
                 Key/value pairs for backend configuration.
                 ServiceInfo shall return a list of keys that a backend supports.
                 Keys are case insensitive.
+                Callers shall pass all runtime or hardware requirement key/values
+                that are not mapped to existing tesResources properties to backend_parameters 
                 Backends shall log system warnings if a key is passed that is unsupported.
                 Backends shall not store or return unsupported keys if included in a task.
                 Backends should attempt to run a task even if key/values are unsupported.


### PR DESCRIPTION
According to the WDL spec, "The runtime section defines key/value pairs for runtime information needed for this task":

https://github.com/openwdl/wdl/blob/master/versions/1.0/SPEC.md#runtime-section

This commit extends tesResources to support an arbitrary dictionary of additional properties, which ensures WDL parsers can pass-through their full list of runtime key/value pairs to a TES backend. The canonical example of its use would be for WDL authors to be able to specify a specific cloud VM SKU in their WDL files.

Please see previous closed PR for discussion: https://github.com/ga4gh/task-execution-schemas/pull/127