### PR TITLE
ci: add OpenAPI linting and validation

### DIFF
--- a/.github/workflows/lint-validate-openapi.yml
+++ b/.github/workflows/lint-validate-openapi.yml
@@ -1,0 +1,51 @@
+name: Lint and validate OpenAPI specs
+
+on:
+  - push
+  - pull_request
+
+jobs:
+
+  lint:
+    name: Lint OpenAPI definition
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out head branch
+        uses: actions/checkout@v2
+      - name: Run OpenAPI Lint Action
+        uses: nwestfall/openapi-action@v1.0.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          file: openapi/task_execution_service.openapi.yaml
+
+  diff:
+    name: Show OpenAPI differences relative to target branch
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
+    steps:
+      - name: Check out head branch
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+          path: head
+      - name: Check out base branch
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.base_ref }}
+          path: base
+      - name: Run OpenAPI Diff Action
+        uses: mvegter/openapi-diff-action@v0.23.5
+        with:
+          head-spec: head/openapi/task_execution_service.openapi.yaml
+          base-spec: base/openapi/task_execution_service.openapi.yaml
+
+  validate:
+    name: Validate OpenAPI definition
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out head branch
+        uses: actions/checkout@v2
+      - name: Run OpenAPI Validate Action
+        uses: char0n/swagger-editor-validate@v1
+        with:
+          definition-file: openapi/task_execution_service.openapi.yaml


### PR DESCRIPTION
Add an additional GitHub actions workflow for OpenAPI linting and validation.

Fixes https://github.com/ga4gh/task-execution-schemas/issues/178

The workflow contains the following three jobs, executed in parallel:

* Action [OpenAPI Lint Action](https://github.com/marketplace/actions/openapi-lint-action), based on [Redocly CLI](https://github.com/Redocly/redocly-cli):  
  - Lints OpenAPI definition at `openapi/task_execution_service.openapi.yaml`
* Action [Swagger Editor Validator](https://github.com/marketplace/actions/swagger-editor-validator), based on a call to [Swagger Editor](https://editor.swagger.io/):
  - Validates the OpenAPI definition at `openapi/task_execution_service.openapi.yaml`
* Action [OpenAPI Diff](https://github.com/marketplace/actions/openapi-diff), based on [OpenAPI Diff](https://bitbucket.org/atlassian/openapi-diff/src/master/):
  - **Only runs for pull requests!**
  - Creates diff between `openapi/task_execution_service.openapi.yaml` definition in head and base/target branch
  - Highlights breaking, non-breaking and unclassified changes
  - Note that check will fail on changes (at least on breaking changes) and GitHub Actions currently does not support `allow-failure` (see [issue](https://github.com/actions/toolkit/issues/399))