### PR TITLE
Add in new tesState for preempted state.

### DIFF
--- a/openapi/task_execution_service.openapi.yaml
+++ b/openapi/task_execution_service.openapi.yaml
@@ -554,7 +554,7 @@ components:
         backend_parameters_strict:
             type: boolean
             description: |-
-                If set to true, backends should fail the task if any backend_parameters
+                If set to true, backends should fail the task if any backend_parameters 
                 key/values are unsupported, otherwise, backends should attempt to run the task
             format: boolean
             default: false
@@ -589,7 +589,7 @@ components:
           tesResources_backend_parameters:
             type: array
             description: |-
-              Lists all tesResources.backend_parameters keys supported
+              Lists all tesResources.backend_parameters keys supported 
               by the service
             items:
               type: string
@@ -623,7 +623,7 @@ components:
         for example an upload failed due to network issues, the worker's ran out
         of disk space, etc.
          - `CANCELED`: The task was canceled by the user.
-         - `PREEMTED`: The task is stopped (preempted) by the system. The reasons for this would be tied to
+         - `PREEMPTED`: The task is stopped (preempted) by the system. The reasons for this would be tied to
         the specific system running the job. Generally, this means that the system reclaimed the compute
         capacity for reallocation.
       default: UNKNOWN
@@ -638,7 +638,7 @@ components:
       - EXECUTOR_ERROR
       - SYSTEM_ERROR
       - CANCELED
-      - PREEMTED
+      - PREEMPTED
     tesTask:
       required:
       - executors

--- a/openapi/task_execution_service.openapi.yaml
+++ b/openapi/task_execution_service.openapi.yaml
@@ -554,7 +554,7 @@ components:
         backend_parameters_strict:
             type: boolean
             description: |-
-                If set to true, backends should fail the task if any backend_parameters 
+                If set to true, backends should fail the task if any backend_parameters
                 key/values are unsupported, otherwise, backends should attempt to run the task
             format: boolean
             default: false
@@ -589,7 +589,7 @@ components:
           tesResources_backend_parameters:
             type: array
             description: |-
-              Lists all tesResources.backend_parameters keys supported 
+              Lists all tesResources.backend_parameters keys supported
               by the service
             items:
               type: string
@@ -623,6 +623,9 @@ components:
         for example an upload failed due to network issues, the worker's ran out
         of disk space, etc.
          - `CANCELED`: The task was canceled by the user.
+         - `PREEMTED`: The task is stopped (preempted) by the system. The reasons for this would be tied to
+        the specific system running the job. Generally, this means that the system reclaimed the compute
+        capacity for reallocation.
       default: UNKNOWN
       example: COMPLETE
       enum:
@@ -635,6 +638,7 @@ components:
       - EXECUTOR_ERROR
       - SYSTEM_ERROR
       - CANCELED
+      - PREEMTED
     tesTask:
       required:
       - executors


### PR DESCRIPTION
Close #183 

Clouds/Job scheduler have preempted rules:

* [GCP](https://cloud.google.com/compute/docs/instances/preemptible)
* [Slurm](https://slurm.schedmd.com/slurm.conf.html#PreemptMode)
* [Azure](https://docs.microsoft.com/en-us/azure/virtual-machines/spot-vms)
* [AWS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/how-spot-instances-work.html)

Solves : https://github.com/microsoft/CromwellOnAzure/issues/451