### PR TITLE
feat: allow wildcards in output paths

### DIFF
--- a/openapi/task_execution_service.openapi.yaml
+++ b/openapi/task_execution_service.openapi.yaml
@@ -450,7 +450,9 @@ components:
         url:
           type: string
           description: |-
-            URL for the file to be copied by the TES server after the task is complete.
+            URL at which the TES server makes the output accessible after the task is complete.
+            When tesOutput.path contains wildcards, it must be a directory; see
+            `tesOutput.path_prefix` for details on how output URLs are constructed in this case.
             For Example:
              - `s3://my-object-store/file1`
              - `gs://my-bucket/file2`
@@ -458,8 +460,18 @@ components:
         path:
           type: string
           description: |-
-            Path of the file inside the container.
-            Must be an absolute path.
+            Absolute path of the file inside the container.
+            May contain pattern matching wildcards to select multiple outputs at once, but mind
+            implications for `tesOutput.url` and `tesOutput.path_prefix`.
+            Only wildcards defined in IEEE Std 1003.1-2017 (POSIX), 12.3 are supported; see
+            https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_13
+        path_prefix:
+          type: string
+          description: |-
+            Prefix to be removed from matching outputs if `tesOutput.path` contains wildcards;
+            output URLs are constructed by appending pruned paths to the directory specfied
+            in `tesOutput.url`.
+            Required if `tesOutput.path` contains wildcards, ignored otherwise.
         type:
           $ref: '#/components/schemas/tesFileType'
       description: Output describes Task output files.


### PR DESCRIPTION
Fixes #77

### Description

This PR adds provisions that allow clients to specify pathname matching wildcards ("globs") when specifying task outputs.

It addresses the discussion points summarized in [this comment](https://github.com/ga4gh/task-execution-schemas/issues/77#issuecomment-1198253120) in the following ways:

- **Should TES implementations be required to support pathname matching in task outputs?**
   Yes. I feel that the use case is sufficiently common that it justifies the added complexity incurred by providing native support in TES, especially since the lack of support for globbing has been a blocker for a more widespread adoption of TES for some upstream implementers, e.g., Nextflow. This proposal adds the provisions for such native support.

- **How to indicate that TES should interpret a specified output as a glob?**
   This proposal requires TES implementations to always apply pathname matching rules to `tesOutput.path` values, unless wildcards are explicitly escaped. This behavior is familiar from (most) shells, completely removes any ambiguities and only alters the `tesOutput.path` description, so no structural changes to the specification are necessary. However, depending on a TES implementer's interpretation of the current specification, it may constitute a breaking change. Specifically, `tesOutput.path` values containing pathname matching wildcards would be treated differently by a TES implementation adopting the proposed change if (and only if) it previously interpreted wildcards literally. However, the expected behavior for paths including wildcards is currently underspecified (implementations may choose to expand or interpret them literally), so the proposed change rather adds clarity to a potential source of ambiguity across implementations.

- **Which globbing rules to prescribe?**
   This proposal suggests prescribing POSIX/Open Group pathname/pattern matching rules, because they are formally specified (see [here](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_13) and [here](https://pubs.opengroup.org/onlinepubs/007908799/xsh/glob.html)), making them compatible with any POSIX-compatible shell environment, including Bash.

- **How to constuct remote storage URLs?**
   This proposal requires clients to do the following, whenever wildcards are used in `tesOutput.path`:

  1. specify a directory for `tesOuput.url`
  2. provide a `tesOutput.path_prefix` (new property) to indicate to TES implementations a prefix to remove from matched pathnames in order to identify the subdirectory tree that is then recreated at the directory specified for `tesOuput.url`  

   This solution fully supports wildcards in any part of `tesOutput.path` while avoiding name clashes, maximizing the control clients have over the eventual location of outputs and being straightforward to implement on the server side.

### Examples

* Use wildcards to copy files from multiple directories whose names are not known (new behavior).

   Outputs to be copied:

   ```console
    /path/in/container/unknown_subdir_1/output.bam
    /path/in/container/unknown_subdir_1/output.sam
    /path/in/container/unknown_subdir_2/output.bam
    /path/in/container/unknown_subdir_2/output.sam
   ```

   Schema values to supply:

   ```yaml
   tesOutput.path: /path/in/container/*/*.?am
   tesOutput.path_prefix: /path/in/container
   tesOutput.url: https://my.storage.org/bucket/
   ```

   URLs of outputs:

   ```console
   https://my.storage.org/bucket/unknown_subdir_1/output.bam
   https://my.storage.org/bucket/unknown_subdir_1/output.sam
   https://my.storage.org/bucket/unknown_subdir_2/output.bam
   https://my.storage.org/bucket/unknown_subdir_2/output.sam
   ```

* Copy a file whose name contains wildcard characters (behavior previously unspecified).

   Output to be copied:

   ```console
   /path/with/wildc*rd_char?
   ```

   Schema values to supply:

   ```yaml
   tesOutput.path: /path/with/wildc\*rd_char\?
   tesOutput.path_prefix: # ignored
   tesOutput.url: https://my.storage.org/bucket/wildc*ard_char?
   ```

   URL of output:

   ```console
   https://my.storage.org/bucket/wildc*ard_char?
   ```
  
* Copy output directory whose name is known (behavior unchanged).

   Output to be copied:

   ```console
   /path/on/container/output/
   ```

   Schema values to supply:

   ```yaml
   tesOutput.path: /path/on/container/output/
   tesOutput.path_prefix: # ignored
   tesOutput.url: https://my.storage.org/bucket/output/
   ```

   URL of output:

   ```console
   https://my.storage.org/bucket/output/
   ```