### PR TITLE
Add CANCELLATION_REQUESTED state to delete cloud resources

### DIFF
--- a/openapi/task_execution_service.openapi.yaml
+++ b/openapi/task_execution_service.openapi.yaml
@@ -622,7 +622,9 @@ components:
          - `SYSTEM_ERROR`: The task was stopped due to a system error, but not from an Executor,
         for example an upload failed due to network issues, the worker's ran out
         of disk space, etc.
-         - `CANCELED`: The task was canceled by the user.
+         - `CANCELED`: The task was canceled by the user, and downstream resources have been deleted.
+         - `CANCELLATION_REQUESTED`: The task was canceled by the user,
+        but the downstream resources are still awaiting deletion
       default: UNKNOWN
       example: COMPLETE
       enum:
@@ -635,6 +637,7 @@ components:
       - EXECUTOR_ERROR
       - SYSTEM_ERROR
       - CANCELED
+      - CANCELLATION_REQUESTED
     tesTask:
       required:
       - executors


### PR DESCRIPTION
Currently TES has a `CANCELED` state.  However, cancelling a task means the associated cloud resources need to be deleted, which can take a few minutes to complete - much longer than is reasonable for an HTTP request timeout.

Proposal: Add a new TES state: `CANCELLATION_REQUESTED`.  When a caller calls the `CancelTask` operation, TES shall return `CANCELED` if and only if all dependent/downstream resources have been deleted.  If it cannot delete the downstream cloud resources during the HTTP request lifetime, it shall return `CANCELLATION_REQUESTED`, until all downstream resources have been deleted.

Example: in Cromwell on Azure, a user can submit a workflow that runs one task.  If a user cancels that workflow while the task is still running, currently, Cromwell will call "CancelTask", and TES will return `CANCELED`. However, at this point, the Azure Batch job and pool have NOT been deleted yet, since this is done by a background thread running on the TES web server.  This is problematic because Cromwell cannot observe whether TES' expensive resources have been deleted yet, which can leave the system in a broken+expensive state, with VMs sitting idle in Azure Batch.  A control plane that is managing the Cromwell environment (such as Terra) can also therefore not observe whether the system has successfully completely cancelled all in-flight workflows.