### PR TITLE
Remove path_prefix from TES specification

### DIFF
--- a/openapi/task_execution_service.openapi.yaml
+++ b/openapi/task_execution_service.openapi.yaml
@@ -525,8 +525,7 @@ components:
           type: string
           description: |-
             URL at which the TES server makes the output accessible after the task is complete.
-            When tesOutput.path contains wildcards, it must be a directory; see
-            `tesOutput.path_prefix` for details on how output URLs are constructed in this case.
+            When tesOutput.path contains wildcards, it must be a directory
             For Example:
              - `s3://my-object-store/file1`
              - `gs://my-bucket/file2`
@@ -536,16 +535,9 @@ components:
           description: |-
             Absolute path of the file inside the container.
             May contain pattern matching wildcards to select multiple outputs at once, but mind
-            implications for `tesOutput.url` and `tesOutput.path_prefix`.
+            implications for `tesOutput.url`
             Only wildcards defined in IEEE Std 1003.1-2017 (POSIX), 12.3 are supported; see
             https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_13
-        path_prefix:
-          type: string
-          description: |-
-            Prefix to be removed from matching outputs if `tesOutput.path` contains wildcards;
-            output URLs are constructed by appending pruned paths to the directory specfied
-            in `tesOutput.url`.
-            Required if `tesOutput.path` contains wildcards, ignored otherwise.
         type:
           $ref: '#/components/schemas/tesFileType'
       description: Output describes Task output files.

--- a/openapi/task_execution_service.openapi.yaml
+++ b/openapi/task_execution_service.openapi.yaml
@@ -525,7 +525,7 @@ components:
           type: string
           description: |-
             URL at which the TES server makes the output accessible after the task is complete.
-            When tesOutput.path contains wildcards, it must be a directory
+            When tesOutput.path contains wildcards, it must be a directory.
             For Example:
              - `s3://my-object-store/file1`
              - `gs://my-bucket/file2`
@@ -535,7 +535,7 @@ components:
           description: |-
             Absolute path of the file inside the container.
             May contain pattern matching wildcards to select multiple outputs at once, but mind
-            implications for `tesOutput.url`
+            implications for `tesOutput.url`.
             Only wildcards defined in IEEE Std 1003.1-2017 (POSIX), 12.3 are supported; see
             https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_13
         type:


### PR DESCRIPTION
`path_prefix` as currently defined in the specification is ambiguous.  It is also a convenience feature, since the local filesystem can be reorganized as needed either by including additional bash commands in the task `command` or by including additional executors.  Therefore, we propose removing it from the specification, as the result of a conversation between @giventocode @vsmalladi @uniqueg @kellrott on 8/17/2023

Addresses: https://github.com/ga4gh/task-execution-schemas/issues/194

