### PR TITLE
auth: mandate JWT bearer token auth

### DIFF
--- a/openapi/task_execution_service.openapi.yaml
+++ b/openapi/task_execution_service.openapi.yaml
@@ -49,14 +49,12 @@ info:
 
     ### Authentication and Authorization
 
-    Is is envisaged that most TES API instances will require users to authenticate to use the endpoints.
-    However, the decision if authentication is required should be taken by TES API implementers.
+    Implementers are required to implement the authentication schemes defined in
+    `components.securitySchemes`, but they are free to define and implement
+    additional schemes as per their requirements.
 
-
-    If authentication is required, we recommend that TES implementations use an OAuth2  bearer token, although they can choose other mechanisms if appropriate.
-
-
-    Checking that a user is authorized to submit TES requests is a responsibility of TES implementations.
+    Checking that a user is authorized to submit TES requests is the responsibility
+    of each implementation.
 
     ### CORS
 

--- a/openapi/task_execution_service.openapi.yaml
+++ b/openapi/task_execution_service.openapi.yaml
@@ -66,6 +66,8 @@ info:
 
 servers:
 - url: /ga4gh/tes/v1
+security:
+  - bearerAuth: []
 paths:
   /service-info:
     get:
@@ -246,6 +248,22 @@ paths:
               schema:
                 $ref: '#/components/schemas/tesCancelTaskResponse'
 components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: |-
+        To access a resource to which this security scheme is applied, a valid JSON
+        JSON Web Token (RFC7519) MUST be passed as a bearer token (RFC6750) in the
+        'Authorization' request header, i.e., `Authorization: Bearer <TOKEN>`. If
+        the header is missing or malformed, or if the token is invalid, servers MUST
+        deny the request with a `401 Unauthorized` response.
+
+        Individual TES instances are encouraged to reference information on token
+        requirements and how a valid token can be obtained in the
+        `GET /service-info` response.
+
   parameters:
     view:
       name: view


### PR DESCRIPTION
Closes #198

The proposed change requires compliant TES implementations to implement JWT-based bearer token authentication.

This will make it easy for client applications to implement the popular [OpenID Connect](https://openid.net/developers/specs/) protocol to authenticate users and generate access tokens that could be used to give access to a varity of GA4GH API-backed microservices, following the [OAuth2](https://datatracker.ietf.org/doc/html/rfc6749) framework.

In fact, this is also the authentication/authorization flow suggested by the current GA4GH [Authentication and Authorization Infrastructure guidelines](https://github.com/ga4gh/data-security/tree/f5187cd3acc1f9d41bd724ca747e1bbc2f2e9f05/AAI).

As highlighted in the overview section of #198, bearer token authentication is also the current consensus across other GA4GH OpenAPI specifications that have defined at least one security scheme.

The suggestions to state `JWT` as the `bearerFormat` (which accepts arbitrary strings but mentions `JWT` in its [documentation](https://swagger.io/docs/specification/authentication/bearer-authentication/)) and to describe the expected behavior explicitly were included to strongly encourage implementers to follow JWT OAuth2 bearer token specifications expressly.

Of course, each implementation can still choose to support any number of alternative, or [additional](https://swagger.io/docs/specification/authentication/), security schemes.

@MattMcL4475