### PR TITLE
Feature: add TesTask.state_description

### DIFF
--- a/openapi/task_execution_service.openapi.yaml
+++ b/openapi/task_execution_service.openapi.yaml
@@ -743,8 +743,7 @@ components:
         state_description:
           type: string
           description: |-
-            OPTIONAL. Additional information about the state of the task.
-            This may be used to provide more information about the state of the task,
+            OPTIONAL. Additional information about the state of the task,
             i.e. `Pending available quota\: low-priority vCPUs`
         name:
           type: string

--- a/openapi/task_execution_service.openapi.yaml
+++ b/openapi/task_execution_service.openapi.yaml
@@ -740,6 +740,12 @@ components:
           example: job-0012345
         state:
           $ref: '#/components/schemas/tesState'
+        state_description:
+          type: string
+          description: |-
+            OPTIONAL. Additional information about the state of the task.
+            This may be used to provide more information about the state of the task,
+            i.e. `Pending available quota\: low-priority vCPUs`
         name:
           type: string
           description: User-provided task name.


### PR DESCRIPTION
Currently, when Azure Batch has no quota available, a TES Task in TES on Azure will stay in the `INITIALIZING` state indefinitely until quota becomes available.  TES needs a way to inform the caller why this is the case, so that the caller can update the UI with this additional information, and the user or IT admin knows they need to submit an Azure Support Request to increase their quota.  Otherwise, they don't have visibility into why the task is not progressing.