### PR TITLE
docs: fix build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,14 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Node.js environment
-        uses: actions/setup-node@v2.5.1
+        uses: actions/setup-node@v4.0.4
         with:
-          node-version: 14.x
+          node-version: 18
           # Comes with npm 6. For newer Node, encountered: https://github.com/npm/cli/issues/3359
       - run: npm install -g @redocly/openapi-cli && npm install -g redoc-cli
       - run: npm install -g gh-openapi-docs
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - run: gh-openapi-docs
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@v4.2.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,17 +1,14 @@
 name: Build OpenAPI docs
-on: 
+on:
   - push
   # - pull_request
 jobs:
   docs-build:
     runs-on: ubuntu-latest
-    # env:
-    #   TRAVIS_BRANCH: ${{ github.event.number }} 
-    #   a trick that builds docs for PRs (with PR number). Does not work for PRs from forks.
     steps:
       - name: Setup Node.js environment
         uses: actions/setup-node@v2.5.1
-        with: 
+        with:
           node-version: 14.x
           # Comes with npm 6. For newer Node, encountered: https://github.com/npm/cli/issues/3359
       - run: npm install -g @redocly/openapi-cli && npm install -g redoc-cli

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,37 +1,33 @@
 name: Lint and validate OpenAPI specs
-
 on:
   - push
-  - pull_request
-
+  - pull_request_target
 jobs:
-
   lint:
     name: Lint OpenAPI definition
     runs-on: ubuntu-latest
     steps:
       - name: Check out head branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run OpenAPI Lint Action
         uses: nwestfall/openapi-action@v1.0.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           file: openapi/task_execution_service.openapi.yaml
-
   diff:
     name: Show OpenAPI differences relative to target branch
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'pull_request' }}
     steps:
       - name: Check out head branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.ref }}
           path: head
       - name: Check out base branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
-          ref: ${{ github.base_ref }}
+          ref: ${{ github.event.pull_request.base.ref }}
           path: base
       - name: Run OpenAPI Diff Action
         uses: mvegter/openapi-diff-action@v0.23.5
@@ -44,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out head branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run OpenAPI Validate Action
         uses: char0n/swagger-editor-validate@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out head branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run OpenAPI Lint Action
         uses: nwestfall/openapi-action@v1.0.2
         with:
@@ -20,12 +20,12 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     steps:
       - name: Check out head branch
-        uses: actions/checkout@v3
+        uses: aactions/checkout@v4
         with:
           ref: ${{ github.ref }}
           path: head
       - name: Check out base branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           path: base
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out head branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run OpenAPI Validate Action
         uses: char0n/swagger-editor-validate@v1
         with:


### PR DESCRIPTION
update build docs so that [main ga4gh page](https://ga4gh.github.io/task-execution-schemas/docs/) is up to date. Closes #197 