### PR TITLE
Update build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - develop
   pull_request:
       types: [opened, reopened, sychronize]
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,8 @@
 name: Build OpenAPI docs
 on:
   push:
+    branches:
+      - main
   pull_request:
       types: [opened, reopened, sychronize]
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
       - develop
+      - 'release*'
   pull_request:
       types: [opened, reopened, sychronize]
 jobs:


### PR DESCRIPTION
The change ensures that workflow runs are only triggered when commits are pushed to the protected branches `main`, `develop` and those starting with `release` - where changes are expected to be merged through PRs. For building docs for feature branches, the `pull_request` trigger will be sufficient.

This setup avoids repeat runs through both the `push` and `pull_request` triggers in most scenarios.