### PR TITLE
fix: Make resources.zones example an array instead of string

### DIFF
--- a/openapi/task_execution_service.openapi.yaml
+++ b/openapi/task_execution_service.openapi.yaml
@@ -641,7 +641,8 @@ components:
             priorty queue to which the job is assigned.
           items:
             type: string
-          example: us-west-1
+          example:
+            - us-west-1
         backend_parameters:
             type: object
             additionalProperties:


### PR DESCRIPTION
The documentation says this should be an array, but the example just has a single string.

<img width="345" height="213" alt="Screenshot 2026-02-11 at 5 10 04 PM" src="https://github.com/user-attachments/assets/017a8bc7-96f5-47d9-af19-8a68bff11c42" />
<img width="549" height="177" alt="Screenshot 2026-02-11 at 5 10 12 PM" src="https://github.com/user-attachments/assets/679963e2-8a56-4901-937c-3af8dedccbcc" />

[Here's the gh-pages from my fork](https://bkdaugherty.github.io/task-execution-schemas/preview/develop/docs/#tag/TaskService/operation/CreateTask), which has it as an array!